### PR TITLE
Fix issues with Line Feed characters being added to configuration values

### DIFF
--- a/lib/go.coffee
+++ b/lib/go.coffee
@@ -41,6 +41,7 @@ class Go
     result = @gopath if @gopath? and @gopath isnt ''
     result = gopathConfig if not environmentOverridesConfig and gopathConfig? and gopathConfig.trim() isnt ''
     result = gopathConfig if result is '' and gopathConfig? and gopathConfig.trim() isnt ''
+    result = result.replace(String.fromCharCode(10), '')
     return @pathexpander.expand(result, '')
 
   splitgopath: ->

--- a/lib/gopath.coffee
+++ b/lib/gopath.coffee
@@ -48,7 +48,7 @@ class Gopath
           message =
               line: false
               column: false
-              msg: 'Warning: GOPATH [' + gopaths[0] + '] does not exist'
+              msg: 'Warning: GOPATH [' + gopath + '] does not exist'
               type: 'warning'
               source: 'gopath'
           messages.push message
@@ -59,7 +59,7 @@ class Gopath
           message =
               line: false
               column: false
-              msg: 'Warning: GOPATH [' + gopaths[0] + '] does not contain a "src" directory - please review http://golang.org/doc/code.html#Workspaces'
+              msg: 'Warning: GOPATH [' + gopath + '] does not contain a "src" directory - please review http://golang.org/doc/code.html#Workspaces'
               type: 'warning'
               source: 'gopath'
           messages.push message


### PR DESCRIPTION
For some reason on OSX my "Go Path" configuration value of "/Users/cstockton/dev/go/dependencies:/Users/cstockton/dev/go/projects" was not working. After some investigation I tracked it down to the Go Path handling in Go Plus. Some how, for some reason, Line Feed terminates the string from the gopath. No clue why. This just strips that line feed character.

I also fixed a couple error messages that were red herrings for my real problem.