### PR TITLE
Cleanup tool finding functions

### DIFF
--- a/lib/go.coffee
+++ b/lib/go.coffee
@@ -49,7 +49,7 @@ class Go
     return result.split(path.delimiter)
 
   gofmt: ->
-    return @gopathBinOrPathItem('gofmt')
+    return @pathOrGoPathBinOrGoToolDirItem('gofmt')
 
   format: ->
     switch atom.config.get('go-plus.formatTool')


### PR DESCRIPTION
There was a duplicate definition of `gocode`, and `gofmt` didn't correctly search `$PATH`, and might as well use the helper function `gopathBinOrPathItem`.
