### PR TITLE
Run golang:gofmt on an unsaved buffer.

### DIFF
--- a/spec/gofmt-spec.coffee
+++ b/spec/gofmt-spec.coffee
@@ -31,6 +31,23 @@ describe "format", ->
     waitsFor ->
       dispatch.ready is true
 
+  it "reformats the file", ->
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
+
+    done = false
+    runs ->
+      dispatch.gofmt.once 'fmt-complete', =>
+        expect(buffer.getText()).toBe "package main\n\nfunc main() {\n}\n"
+        expect(dispatch.messages?).toBe true
+        expect(_.size(dispatch.messages)).toBe 0
+        done = true
+      buffer.setText("package main\n\nfunc main()  {\n}\n")
+      atom.commands.dispatch workspaceElement, 'golang:gofmt'
+
+    waitsFor ->
+      done is true
+
   describe "when format on save is enabled", ->
     beforeEach ->
       atom.config.set("go-plus.formatOnSave", true)


### PR DESCRIPTION
I did an attempt to implement the `gofmt` on unsaved buffers as reported in issue #126. 

The unsaved buffer is written to a temporary file. Then `gofmt` is run on that temporary file and its content is read again into the current buffer.

I haven't done any CoffeeScript nor Atom package development before. So feedback is welcome.