### PR TITLE
Godef command

### DIFF
--- a/examples/godef/hasDefinitions.go
+++ b/examples/godef/hasDefinitions.go
@@ -2,16 +2,18 @@ package main
 
 import "fmt"
 
-var test = "test string"
+var sausage testStruct
 
 type testStruct struct {
 	x int
 	y string
 }
 
+var test = "test string"
+
 func main() {
-	x := testStruct{}
-	fmt.Printf("%s, struct is of type %T\ntest is %s", hello(), x, test)
+	sausage = testStruct{}
+	fmt.Printf("%s, struct is of type %T\ntest is %s", hello(), sausage, test)
 }
 
 func hello() string {

--- a/examples/godef/hasDefinitions.go
+++ b/examples/godef/hasDefinitions.go
@@ -2,18 +2,21 @@ package main
 
 import "fmt"
 
-var sausage testStruct
+var (
+	testvar1 = "test string"
+	testvar2 int
+)
 
 type testStruct struct {
 	x int
 	y string
 }
 
-var test = "test string"
+var testvar3 testStruct
 
 func main() {
-	sausage = testStruct{}
-	fmt.Printf("%s, struct is of type %T\ntest is %s", hello(), sausage, test)
+	testvar3 = testStruct{}
+	fmt.Printf("%s, struct is of type %T\ntest is %s", hello(), testvar3, testvar1)
 }
 
 func hello() string {

--- a/examples/godef/hasDefinitions.go
+++ b/examples/godef/hasDefinitions.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+var test = "test string"
+
+type testStruct struct {
+	x int
+	y string
+}
+
+func main() {
+	x := testStruct{}
+	fmt.Printf("%s, struct is of type %T\ntest is %s", hello(), x, test)
+}
+
+func hello() string {
+	return "Hello, 世界"
+}

--- a/keymaps/go-plus.cson
+++ b/keymaps/go-plus.cson
@@ -3,4 +3,5 @@
 '.editor':
   'ctrl-alt-c': 'golang:gocover'
   'ctrl-alt-shift-c': 'golang:cleargocover'
-  'ctrl-alt-cmd-t': 'golang:godef' # TODO testing only. Remove
+  # TODO testing only. Remove
+  'alt-cmd-g': 'golang:godef' 

--- a/keymaps/go-plus.cson
+++ b/keymaps/go-plus.cson
@@ -3,5 +3,4 @@
 '.editor':
   'ctrl-alt-c': 'golang:gocover'
   'ctrl-alt-shift-c': 'golang:cleargocover'
-  # TODO testing only. Remove
-  'alt-cmd-g': 'golang:godef' 
+  'alt-cmd-g': 'golang:godef'

--- a/keymaps/go-plus.cson
+++ b/keymaps/go-plus.cson
@@ -3,3 +3,4 @@
 '.editor':
   'ctrl-alt-c': 'golang:gocover'
   'ctrl-alt-shift-c': 'golang:cleargocover'
+  'ctrl-alt-cmd-t': 'golang:godef' # TODO testing only. Remove

--- a/lib/dispatch.coffee
+++ b/lib/dispatch.coffee
@@ -231,6 +231,12 @@ class Dispatch
       else
         @messagepanel.add new PlainMessageView raw: true, message: '<b>Gocode Tool:</b> Not Found', className: 'text-error'
 
+      # godef
+      if go.godef()? and go.godef() isnt false
+        @messagepanel.add new PlainMessageView raw: true, message: '<b>Godef Tool:</b> ' + go.godef(), className: 'text-subtle'
+      else
+        @messagepanel.add new PlainMessageView raw: true, message: '<b>Godef Tool:</b> Not Found', className: 'text-error'
+
       # gocode active
       if _.contains(atom.packages.getAvailablePackageNames(), 'autocomplete-plus')
         @messagepanel.add new PlainMessageView raw: true, message: '<b>Gocode Status:</b> Enabled', className: 'text-subtle'

--- a/lib/dispatch.coffee
+++ b/lib/dispatch.coffee
@@ -9,6 +9,7 @@ Gocode = require './gocode'
 Executor = require './executor'
 Environment = require './environment'
 GoExecutable = require './goexecutable'
+Godef = require './godef'
 SplicerSplitter = require './util/splicersplitter'
 _ = require 'underscore-plus'
 {MessagePanelView, LineMessageView, PlainMessageView} = require 'atom-message-panel'
@@ -41,6 +42,7 @@ class Dispatch
     @gobuild = new Gobuild(this)
     @gocover = new Gocover(this)
     @gocode = new Gocode(this)
+    @godef = new Godef(this)
 
     @messagepanel = new MessagePanelView title: '<span class="icon-diff-added"></span> go-plus', rawTitle: true unless @messagepanel?
 
@@ -80,6 +82,7 @@ class Dispatch
     @gopath.destroy()
     @gofmt.destroy()
     @gocode.destroy()
+    @godef.destroy()
     @gocover = null
     @gobuild = null
     @golint = null
@@ -87,6 +90,7 @@ class Dispatch
     @gopath = null
     @gofmt = null
     @gocode = null
+    @godef = null
     @ready = false
     @activated = false
     @emit 'destroyed'

--- a/lib/go.coffee
+++ b/lib/go.coffee
@@ -86,6 +86,9 @@ class Go
   gocode: ->
     return @gopathBinOrPathItem('gocode')
 
+  godef: ->
+    return @goTooldirOrGopathBinOrPathItem('godef')
+
   oracle: ->
     return @gopathBinOrPathItem('oracle')
 
@@ -154,4 +157,5 @@ class Go
     return true if @oracle() is false
     return true if @git() is false
     return true if @hg() is false
+    return true if @godef() is false
     return false

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -40,7 +40,7 @@ class Godef
     @gotoDefinitionForWord word, done
 
   gotoDefinitionForWord: (word, callback = ->) ->
-    message = {}
+    message = null
 
     unless word.length > 0
       message =
@@ -58,6 +58,9 @@ class Godef
         # atom's cursors 0-based; godef uses diff-like 1-based
         line = parseInt(outputs[1],10) - 1
         col = parseInt(outputs[2],10) - 1
+
+        console.log "line: #{line}, col: #{col}"
+
         targetFilePath = outputs[0]
         if targetFilePath == @editor.getPath()
           @editor.setCursorBufferPosition [col, line]

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -1,6 +1,4 @@
 {Emitter, Subscriber} = require 'emissary'
-# should use event-kit as per http://blog.atom.io/2014/09/16/new-event-subscription-api.html
-# (so far unable to get subscriptions to work)
 path = require 'path'
 
 module.exports =
@@ -12,6 +10,7 @@ class Godef
     @commandName = "golang:godef"
     @dispatch = dispatch
     @name = 'def'
+    @onCompleteNotification = "#{@name}-complete"
     @warningNotFoundMessage = 'No word under cursor to define'
     atom.commands.add 'atom-workspace',
       'golang:godef': => @gotoDefinitionForWordAtCursor()
@@ -23,6 +22,11 @@ class Godef
 
   reset: (editor) ->
     @emit 'reset', @editor
+
+  # new pattern as per http://blog.atom.io/2014/09/16/new-event-subscription-api.html
+  # (so far unable to get event-kit subscriptions to work)
+  onDidComplete: (callback) ->
+    @on @onCompleteNotification, callback
 
   gotoDefinitionForWordAtCursor: ->
     @editor = atom?.workspace?.getActiveTextEditor()
@@ -49,10 +53,20 @@ class Godef
         if exitcode == 0
           outputs = stdout.split ":"
           # atom's cursors 0-based; godef uses diff 1-based
-          wordPoint = [parseInt(outputs[1],10) - 1,parseInt(outputs[2],10) - 1]
-          @editor.setCursorBufferPosition wordPoint
-          @emit "#{@name}-complete", @editor, false
-        else
+          line = parseInt(outputs[1],10) - 1
+          col = parseInt(outputs[2],10) - 1
+          filePath = outputs[0]
+          if filePath == @editor.getPath()
+            @editor.setCursorBufferPosition [col, line]
+            @emit @onCompleteNotification, @editor, false
+          else
+            console.log "opening #{filePath}"
+            atom.workspace.open(filePath, {initialLine:line, initialColumn:col}).then (e) =>
+              # should @editor here be the new one? How's it used in dispatch?
+              @emit @onCompleteNotification, @editor, false
+
+
+        else # godef can't find def
           # TODO report failures  as per else clause below (not an id; not found)
           # TODO remove temp
           console.log 'no bloody good'

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -1,0 +1,71 @@
+###
+  TODO
+  - fix 'error deactiviating go-plus'
+ Questions
+
+  - why function/method args sometimes, sometimes not, in brackets? (happily
+    inconsistent, or is there a patter I'm not seeing?)
+  -
+
+ ###
+
+
+{Emitter, Subscriber} = require 'emissary'
+
+module.exports =
+class Godef
+  Subscriber.includeInto(this)
+  Emitter.includeInto(this)
+
+  constructor: (dispatch) ->
+    @commandName = "golang:godef"
+    @dispatch = dispatch
+    @name = 'def'
+    @warningNotFoundMessage = 'No word under cursor to define'
+    atom.commands.add 'atom-workspace',
+      'golang:godef': => @gotoDefinitionForWordAtCursor()
+
+  destroy: ->
+    @unsubscribe()
+    @dispatch = null
+
+  reset: (editor) ->
+    @emit 'reset', editor
+
+  gotoDefinitionForWordAtCursor: ->
+    editor = atom?.workspace?.getActiveTextEditor()
+    return unless @dispatch.isValidEditor editor
+    @reset editor
+    done = (err, messages) =>
+      @dispatch.resetAndDisplayMessages editor, messages
+    @gotoDefinitionForWord  @wordAtCursor(editor), done
+
+
+  gotoDefinitionForWord: (word, callback = ->) ->
+    console.log "Finding definition for word: #{word}"
+    messages = {}
+    if word.length > 0 then
+      # invoke godef with word and capture output
+      # if +'ve, capture filename, line, col
+      # report this for goplus panel?
+      # open and make new editor with filename
+      # place cursor at line and column
+      # report to dispatch / goplus for panel ??
+      #atom.workspace.open('/tmp/txt')
+
+    else
+      message =
+        line: false
+        column: false
+        msg: @warningNotFoundMessage
+        type: 'warning'
+        source: @name
+
+    callback null, [message]
+
+
+
+  wordAtCursor: (editor )->
+    # options =
+    #   wordRegex: /\w+\.\w+/
+    return editor.getWordUnderCursor()

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -71,7 +71,7 @@ class Godef
         callback null, [message]
       else
         atom.workspace.open(targetFilePath, {initialLine:row, initialColumn:col}).then (e) =>
-          @cursorOnChangeSubscription = @highlightWordAtCursor(atom.workspace.getActiveEditor())
+          @cursorOnChangeSubscription = @highlightWordAtCursor(atom.workspace.getActiveTextEditor())
           @emit @didCompleteNotification, @editor, false
           callback null, [message]
 
@@ -105,7 +105,7 @@ class Godef
   wordAtCursor: (editor = @editor) ->
     options =
       wordRegex: /[\w+\.]*/
-    cursor = editor.getCursor()
+    cursor = editor.getLastCursor()
     range = cursor.getCurrentWordBufferRange(options)
     word = @editor.getTextInBufferRange(range)
     return {word: word, range: range}
@@ -114,5 +114,5 @@ class Godef
     {word, range} = @wordAtCursor(editor)
     highlightMarker = editor.markBufferRange(range, {invalidate:'inside'})
     highlightDecoration = editor.decorateMarker(highlightMarker, {type:'highlight', class:'goplus-godef-highlight'})
-    cursor = editor.getCursor()
+    cursor = editor.getLastCursor()
     cursor.onDidChangePosition ->  highlightMarker.destroy()

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -39,13 +39,9 @@ class Godef
     @gotoDefinitionForWord  @wordAtCursor(), done
 
   gotoDefinitionForWord: (word, callback = ->) ->
-    # TODO remove temp
-    console.log "Finding definition for word: *#{word}*"
     message = {}
 
     unless word.length > 0
-      # TODO remove temp
-      console.log "NOTHING TO DEFINE"
       message =
         line: false
         column: false
@@ -56,8 +52,6 @@ class Godef
       return
 
     done = (exitcode, stdout, stderr, messages) =>
-      # TODO remove temp
-      console.log "Godef exitcode: #{exitcode}, reported: #{stdout}" # TODO remove temp
       if exitcode == 0
         outputs = stdout.split ":"
         # atom's cursors 0-based; godef uses diff-like 1-based
@@ -66,15 +60,12 @@ class Godef
         targetFilePath = outputs[0]
         if targetFilePath == @editor.getPath()
           @editor.setCursorBufferPosition [col, line]
+          # @editor.markBufferRange([[1,1], ])
           @emit @didCompleteNotification, @editor, false
         else
-          # TODO remove temp
-          console.log "opening #{targetFilePath}"
           atom.workspace.open(targetFilePath, {initialLine:line, initialColumn:col}).then (e) =>
             @emit @didCompleteNotification, @editor, false
       else # godef can't find def
-        # TODO remove temp
-        console.log 'GODEF FOUND NO DEF'
         message =
           line: false
           column: false
@@ -84,12 +75,11 @@ class Godef
       callback null, [message]
 
     cmd = 'godef'
-    env = null
+    env = @dispatch.env()
     filePath = @editor.getPath()
     cwd = path.dirname(filePath)
     args = ['-f', filePath, word]
 
-    console.log "about to dispatch #{cmd}"
     @dispatch.executor.exec(cmd, cwd, env, done, args)
 
   wordAtCursor: ->

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -12,8 +12,6 @@ class Godef
     @dispatch = dispatch
     @name = 'def'
     @didCompleteNotification = "#{@name}-complete"
-    @warningNotFoundMessage = "No word under cursor to define"
-    @warningMultipleCursorsMessage = "Godef only works with a single cursor"
     atom.commands.add 'atom-workspace',
       'golang:godef': => @gotoDefinitionForWordAtCursor()
     @cursorOnChangeSubscription = null
@@ -27,7 +25,7 @@ class Godef
     @cursorOnChangeSubscription?.dispose()
 
   # new pattern as per http://blog.atom.io/2014/09/16/new-event-subscription-api.html
-  # (but so far unable to get event-kit subscriptions to work)
+  # (but so far unable to get event-kit subscriptions to work, so keeping emissary)
   onDidComplete: (callback) =>
     @on @didCompleteNotification, callback
 
@@ -42,7 +40,7 @@ class Godef
       message =
         line: false
         column: false
-        msg: @warningMultipleCursorsMessage
+        msg: "Godef only works with a single cursor"
         type: 'warning'
         source: @name
       done null, [message]
@@ -58,7 +56,7 @@ class Godef
       message =
         line: false
         column: false
-        msg: @warningNotFoundMessage
+        msg: "No word under cursor to define"
         type: 'warning'
         source: @name
       callback null, [message]
@@ -72,7 +70,7 @@ class Godef
           message =
             line: false
             column: false
-            msg: "godef suggested a file path (\"#{targetFilePath}\") that does not exist)"
+            msg: @warningFileDoesNotExistMessage = "godef suggested a file path (\"#{targetFilePath}\") that does not exist)"
             type: 'warning'
             source: @name
           callback null, [message]
@@ -123,7 +121,6 @@ class Godef
     options =
       wordRegex: /[\w+\.]*/
     cursor = editor.getCursor()
-    # TODO this is probably a furphy. It's the range of godef's output that's needed
     range = cursor.getCurrentWordBufferRange(options)
     word = @editor.getTextInBufferRange(range)
     return {word: word, range: range}

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -56,18 +56,15 @@ class Godef
       if exitcode == 0
         outputs = stdout.split ":"
         # atom's cursors 0-based; godef uses diff-like 1-based
-        line = parseInt(outputs[1],10) - 1
+        row = parseInt(outputs[1],10) - 1
         col = parseInt(outputs[2],10) - 1
-
-        console.log "line: #{line}, col: #{col}"
-
         targetFilePath = outputs[0]
         if targetFilePath == @editor.getPath()
-          @editor.setCursorBufferPosition [col, line]
+          @editor.setCursorBufferPosition [row, col]
           @highlightWordAtCursor()
           @emit @didCompleteNotification, @editor, false
         else
-          atom.workspace.open(targetFilePath, {initialLine:line, initialColumn:col}).then (e) =>
+          atom.workspace.open(targetFilePath, {initialLine:row, initialColumn:col}).then (e) =>
             @highlightWordAtCursor(atom.workspace.getActiveEditor())
             @emit @didCompleteNotification, @editor, false
       else # godef can't find def

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -81,12 +81,15 @@ class Godef
             @emit @didCompleteNotification, @editor, false
             callback null, [message]
       else # godef can't find def
+        # little point parsing the error further, given godef bugs eg
+        # "godef: cannot parse expression: <arg>:1:1: expected operand, found 'return'"
         message =
           line: false
           column: false
-          msg: "godef could not find definition for #{word}"
+          msg: stderr
           type: 'warning'
           source: @name
+        callback null, [message]
 
     go = @dispatch.goexecutable.current()
     cmd = go.godef()

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -10,8 +10,8 @@ class Godef
     @commandName = "golang:godef"
     @dispatch = dispatch
     @name = 'def'
-    @onCompleteNotification = "#{@name}-complete"
-    @warningNotFoundMessage = 'No word under cursor to define'
+    @didCompleteNotification = "#{@name}-complete"
+    @warningNotFoundMessage = "No word under cursor to define"
     atom.commands.add 'atom-workspace',
       'golang:godef': => @gotoDefinitionForWordAtCursor()
     @emitter = new Emitter
@@ -26,58 +26,25 @@ class Godef
   # new pattern as per http://blog.atom.io/2014/09/16/new-event-subscription-api.html
   # (so far unable to get event-kit subscriptions to work)
   onDidComplete: (callback) ->
-    @on @onCompleteNotification, callback
+    @on @didCompleteNotification, callback
 
   gotoDefinitionForWordAtCursor: ->
     @editor = atom?.workspace?.getActiveTextEditor()
-    return unless @dispatch.isValidEditor @editor
+    unless @dispatch.isValidEditor @editor
+      @emit @didCompleteNotification, @editor, false
+      return
     @reset @editor
     done = (err, messages) =>
       @dispatch.resetAndDisplayMessages @editor, messages
     @gotoDefinitionForWord  @wordAtCursor(), done
 
   gotoDefinitionForWord: (word, callback = ->) ->
-
     # TODO remove temp
     console.log "Finding definition for word: *#{word}*"
-    message = []
-    if word.length > 0
-      # TODO follow go-plus pattern for cmd invocation
-      command = 'godef'
-      env = null
-      filename = @editor.getPath()
-      cwd = path.dirname(filename)
-      args = ['-f', filename, word]
-      done = (exitcode, stdout, stderr, messages) =>
-        console.log "#{command} exitcode: #{exitcode}, reported: #{stdout}" # TODO remove temp
-        if exitcode == 0
-          outputs = stdout.split ":"
-          # atom's cursors 0-based; godef uses diff 1-based
-          line = parseInt(outputs[1],10) - 1
-          col = parseInt(outputs[2],10) - 1
-          filePath = outputs[0]
-          if filePath == @editor.getPath()
-            @editor.setCursorBufferPosition [col, line]
-            @emit @onCompleteNotification, @editor, false
-          else
-            console.log "opening #{filePath}"
-            atom.workspace.open(filePath, {initialLine:line, initialColumn:col}).then (e) =>
-              # should @editor here be the new one? How's it used in dispatch?
-              @emit @onCompleteNotification, @editor, false
+    message = {}
 
-
-        else # godef can't find def
-          # TODO report failures  as per else clause below (not an id; not found)
-          # TODO remove temp
-          console.log 'no bloody good'
-
-      @dispatch.executor.exec(command, cwd, env, done, args)
-      # if +'ve, capture filename, line, col
-      # report this for goplus panel?
-      # open and make new editor with filename
-      # place cursor at line and column
-      # report to dispatch / goplus for panel ??
-    else # no word found
+    unless word.length > 0
+      # TODO remove temp
       console.log "NOTHING TO DEFINE"
       message =
         line: false
@@ -85,8 +52,45 @@ class Godef
         msg: @warningNotFoundMessage
         type: 'warning'
         source: @name
+      callback null, [message]
+      return
 
-    callback null, [message]
+    done = (exitcode, stdout, stderr, messages) =>
+      # TODO remove temp
+      console.log "Godef exitcode: #{exitcode}, reported: #{stdout}" # TODO remove temp
+      if exitcode == 0
+        outputs = stdout.split ":"
+        # atom's cursors 0-based; godef uses diff-like 1-based
+        line = parseInt(outputs[1],10) - 1
+        col = parseInt(outputs[2],10) - 1
+        targetFilePath = outputs[0]
+        if targetFilePath == @editor.getPath()
+          @editor.setCursorBufferPosition [col, line]
+          @emit @didCompleteNotification, @editor, false
+        else
+          # TODO remove temp
+          console.log "opening #{targetFilePath}"
+          atom.workspace.open(targetFilePath, {initialLine:line, initialColumn:col}).then (e) =>
+            @emit @didCompleteNotification, @editor, false
+      else # godef can't find def
+        # TODO remove temp
+        console.log 'GODEF FOUND NO DEF'
+        message =
+          line: false
+          column: false
+          msg: "godef could not find definition for #{word}"
+          type: 'warning'
+          source: @name
+      callback null, [message]
+
+    cmd = 'godef'
+    env = null
+    filePath = @editor.getPath()
+    cwd = path.dirname(filePath)
+    args = ['-f', filePath, word]
+
+    console.log "about to dispatch #{cmd}"
+    @dispatch.executor.exec(cmd, cwd, env, done, args)
 
   wordAtCursor: ->
     options =

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -88,7 +88,17 @@ class Godef
           type: 'warning'
           source: @name
 
-    cmd = 'godef'
+    go = @dispatch.goexecutable.current()
+    cmd = go.godef()
+    if cmd is false
+      message =
+        line: false
+        column: false
+        msg: 'Godef Tool Missing'
+        type: 'error'
+        source: @name
+      callback(null, [message])
+      return
     env = @dispatch.env()
     filePath = @editor.getPath()
     cwd = path.dirname(filePath)

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -26,7 +26,7 @@ class Godef
 
   # new pattern as per http://blog.atom.io/2014/09/16/new-event-subscription-api.html
   # (but so far unable to get event-kit subscriptions to work)
-  onDidComplete: (callback) ->
+  onDidComplete: (callback) =>
     @on @didCompleteNotification, callback
 
   gotoDefinitionForWordAtCursor: ->
@@ -64,10 +64,12 @@ class Godef
           @editor.setCursorBufferPosition [row, col]
           @cursorOnChangeSubscription = @highlightWordAtCursor()
           @emit @didCompleteNotification, @editor, false
+          callback null, [message]
         else
           atom.workspace.open(targetFilePath, {initialLine:row, initialColumn:col}).then (e) =>
             @cursorOnChangeSubscription = @highlightWordAtCursor(atom.workspace.getActiveEditor())
             @emit @didCompleteNotification, @editor, false
+            callback null, [message]
       else # godef can't find def
         message =
           line: false
@@ -75,7 +77,6 @@ class Godef
           msg: "godef could not find definition for #{word}"
           type: 'warning'
           source: @name
-      callback null, [message]
 
     cmd = 'godef'
     env = @dispatch.env()

--- a/lib/goexecutable.coffee
+++ b/lib/goexecutable.coffee
@@ -209,6 +209,13 @@ class GoExecutable
       (callback) =>
         done = (exitcode, stdout, stderr) =>
           callback(null)
+        if go.godef() isnt false and not updateExistingTools
+          done()
+        else
+          @executor.exec(go.executable, false, gogetenv, done, ['get', '-u', 'code.google.com/p/rog-go/exp/cmd/godef'])
+      (callback) =>
+        done = (exitcode, stdout, stderr) =>
+          callback(null)
         if go.oracle() isnt false and not updateExistingTools
           done()
         else

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,17 +1,22 @@
 ###
   TODO
-  - match godef cmd invocation approach to existing go-plus
+  - match godef cmd invocation approach to existing go-plus approach
+  - scroll target to put the def line at top of ed pane?
   - fix bug in cursor-moving test
   - how to test for dispatch of a command?
   - check for paths of exe and source files on Windows
   - copy test text from test file instead of using string lits?
   - deal with multiple cursors
-  - scroll target to put the def line at top of ed pane?
+  - why can item in `for _, item := range env {` not be found by godef?
 
  Questions for
 
   - why function/method args sometimes, sometimes not, in brackets? (happily
     inconsistent, or is there a patter I'm not seeing?)
+  - gofmt has a buffer existence check: `buffer = editor?.getBuffer()`
+    Under what circumstances would a valid (*.go) active text editor not have a
+    buffer?
+
 
     A good reason to keep consistent: f() looks a lot like f () ->
 
@@ -23,7 +28,7 @@ temp = require('temp').track()
 _ = require ("underscore-plus")
 {Subscriber} = require 'emissary'
 
-describe "godef", ->
+fdescribe "godef", ->
   [editor, editorView, dispatch, filePath, workspaceElement] = []
   testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}\n\n"
 
@@ -120,7 +125,7 @@ describe "godef", ->
            editor.isModified() is false
 
         # TODO fix something async-funky making this test fail
-        fdescribe "defined within the current file", ->
+        xdescribe "defined within the current file", ->
           it "should move the cursor to the definition", ->
             done = false
             subscription = dispatch.godef.onDidComplete ->

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,14 +1,14 @@
 ###
   TODO - Essential
-  - BUG: 
+  - BUG:
     "Uncaught TypeError: Cannot read property 'checkBuffer' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (583)
       (in dispatch::triggerPipeline)
      "Uncaught TypeError: Cannot read property 'add' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (752)
       (in dispatch::updatePane)
     No idea about this as yet
 
+  * deal with multiple cursors
   - how to test for dispatch of a command?
-  - deal with multiple cursors
   - check for paths of exe and source files on Windows?
   - thorough playing to destruction with lots of go files
     (use on a couple of days' Go programming)
@@ -38,7 +38,7 @@ temp = require('temp').track()
 _ = require ("underscore-plus")
 {Subscriber} = require 'emissary'
 
-fdescribe "godef", ->
+describe "godef", ->
   [editor, editorView, dispatch, filePath, workspaceElement] = []
   testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}\n\n"
 
@@ -119,6 +119,26 @@ fdescribe "godef", ->
       expect(godefCommand.length).toEqual(1)
 
   describe "when godef command is invoked", ->
+    beforeEach ->
+      editor.setText testText
+      editor.save()
+
+    waitsFor ->
+      editor.isModified() is false
+
+    fdescribe "if there is more than one cursor", ->
+      it "displays a warning message", ->
+          editor.setCursorBufferPosition([0,0])
+          editor.addCursorAtBufferPosition([1,0])
+          atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe 1
+          expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningMultipleCursorsMessage)
+
+      it "should not dispatch godef", ->
+        expect(false).toBe(true)
+
+
       describe "with no word under the cursor", ->
         beforeEach ->
           editor.setText ""

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,18 +1,22 @@
 ###
-  TODO
-  - bug?: never dispose() cursor subscriptions in godef.coffee
-  - bug: own-file def presents go-plus message window (empty)
+  TODO - Essential
+  * bug: subsequent invocations jump to previous definition
   - bug: "Uncaught TypeError: Cannot read property 'add' of null",
-  - scroll target to put the def line at top of ed pane when it's in a different file?
+  - bug?: never dispose() cursor subscriptions in godef.coffee
   - how to test for dispatch of a command?
-  - should I use mapMessages approach? I'm forking based on exitcode.
+  - thorough playing to destruction with lots of go files
+    (use on a couple of days' Go programming)
   - check for paths of exe and source files on Windows
-  - copy test text from test file instead of using string lits?
   - deal with multiple cursors
   - why can item in `for _, item := range env {` not be found by godef?
+
+  TODO - Enhancements
+  - copy test text from test file instead of using string lits?
+  - scroll target to put the def line at top of ed pane when it's in a different file?
+  - should I use mapMessages approach? I'm forking based on exitcode.
   - consider -webkit-animation: to animate the definition highlight?
 
- Questions for
+ Questions for package maintainer
 
   - why function/method args sometimes, sometimes not, in brackets? (happily
     inconsistent, or is there a patter I'm not seeing?)

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,9 +1,11 @@
 ###
   TODO
-  - match godef cmd invocation approach to existing go-plus approach
+  - highlight defined term
+    (see https://atom.io/docs/api/v0.174.0/Decoration)
   - scroll target to put the def line at top of ed pane?
   - fix bug in cursor-moving test
   - how to test for dispatch of a command?
+  - should I use mapMessages approach? I'm forking based on exitcode.
   - check for paths of exe and source files on Windows
   - copy test text from test file instead of using string lits?
   - deal with multiple cursors
@@ -28,7 +30,7 @@ temp = require('temp').track()
 _ = require ("underscore-plus")
 {Subscriber} = require 'emissary'
 
-fdescribe "godef", ->
+describe "godef", ->
   [editor, editorView, dispatch, filePath, workspaceElement] = []
   testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}\n\n"
 

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,14 +1,12 @@
 ###
   TODO - Essential
-  * bug: subsequent invocations jump to previous definition
+  * bug: never dispose() cursor subscriptions in godef.coffee
   - bug: "Uncaught TypeError: Cannot read property 'add' of null",
-  - bug?: never dispose() cursor subscriptions in godef.coffee
   - how to test for dispatch of a command?
+  - deal with multiple cursors
+  - check for paths of exe and source files on Windows?
   - thorough playing to destruction with lots of go files
     (use on a couple of days' Go programming)
-  - check for paths of exe and source files on Windows
-  - deal with multiple cursors
-  - why can item in `for _, item := range env {` not be found by godef?
 
   TODO - Enhancements
   - copy test text from test file instead of using string lits?

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,0 +1,74 @@
+# TODO:
+# get the 1st test to pass
+
+path = require 'path'
+fs = require 'fs-plus'
+temp = require('temp').track()
+_ = require ("underscore-plus")
+
+describe "godef", ->
+  [editor, editorView, dispatch, buffer, filePath, workspaceElement] = []
+
+  beforeEach ->
+    directory = temp.mkdirSync()
+    atom.project.setPaths(directory)
+    filePath = path.join(directory, 'go-plus-testing.go')
+    fs.writeFileSync(filePath, '')
+    workspaceElement = atom.views.getView(atom.workspace)
+    jasmine.attachToDOM(workspaceElement)
+
+    waitsForPromise -> atom.workspace.open(filePath).then (e) ->
+      editor = e
+      editorView = atom.views.getView(editor)
+
+    waitsForPromise ->
+      atom.packages.activatePackage('language-go')
+
+    waitsForPromise ->
+      atom.packages.activatePackage('go-plus')
+
+    runs ->
+      buffer = editor.getBuffer()
+      dispatch = atom.packages.getLoadedPackage('go-plus').mainModule.dispatch
+      dispatch.goexecutable.detect()
+
+    waitsFor ->
+      dispatch.ready is true
+
+  describe "when go-plus is loaded", ->
+    it "should have registered the golang:godef command",  ->
+      currentCommands = atom.commands.findCommands({target: editorView})
+      # get name from the godef package, rather than magick'd here?
+      godefCommand = (cmd for cmd in currentCommands when cmd.name is dispatch.godef.commandName)
+      expect(godefCommand.length).toEqual(1)
+
+  describe "when godef command is invoked", ->
+      describe "with no word under the cursor", ->
+        it "displays a warning message", ->
+          atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe 1
+          expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningNotFoundMessage)
+
+        it "should not dispatch godef", ->
+          expect(false).toBe(true)
+
+
+      describe "with the cursor on a word start", ->
+        fit "should open a new text editor", ->
+          wordToDefine = "word"
+          editor.setText(wordToDefine)
+          editor.setCursorBufferPosition([1,1])
+          atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
+
+          done = false
+          runs ->
+            expect(atom.workspace.getActiveTextEditor()).not.toBe(editor)
+            # This fails, because the open is asynchronous (at this stage we have the .go source file still)
+            # How to test this? The command dispatch sets off an asynchronous open
+            # (ie. of the file containing the word definition)
+            # The command dispatch does not itself return a promise. So what is there to wait for
+            done = true
+
+          waitsFor ->
+            done is true

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -6,15 +6,13 @@
      "Uncaught TypeError: Cannot read property 'add' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (752)
       (in dispatch::updatePane)
     No idea about this as yet
-  * Bug: opens empty file "-" when invoked on simple type names (int, string etc)
 
-  - refactor godef:gotoDefinitionForWord
-  - research godef "# godef: cannot parse expression: <arg>:1:1: expected operand, found 'return'"
+  * refactor messy godef::gotoDefinitionForWord
   - thorough playing to destruction with lots of go files
     (use on a couple of days' Go programming)
-  - refactor messy godef::gotoDefinitionForWord
 
   TODO - Enhancements
+  - research godef "# godef: cannot parse expression: <arg>:1:1: expected operand, found 'return'"
   - copy test text from test file instead of using string lits
   - scroll target to put the def line at top of ed pane when it's in a different file?
   - should I use mapMessages approach? I'm forking based on exitcode.
@@ -37,7 +35,8 @@ temp = require('temp').track()
 _ = require ("underscore-plus")
 {Subscriber} = require 'emissary'
 
-describe "godef", ->
+# TODO remove temp fdescribe
+fdescribe "godef", ->
   [editor, editorView, dispatch, filePath, workspaceElement] = []
   testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}\n\n"
 
@@ -73,7 +72,7 @@ describe "godef", ->
       godef.editor = editor
       editor.setText("foo foo.bar bar")
 
-    fit "should return foo for |foo", ->
+    it "should return foo for |foo", ->
       editor.setCursorBufferPosition([0,0])
       {word, range} = godef.wordAtCursor()
       expect(word).toEqual('foo')
@@ -105,7 +104,7 @@ describe "godef", ->
       expect(word).toEqual('foo.bar')
       expect(range).toEqual([[0,4], [0,11]])
 
-    fit "should return foo.bar for foo.ba|r", ->
+    it "should return foo.bar for foo.ba|r", ->
       editor.setCursorBufferPosition([0,10])
       {word, range} = godef.wordAtCursor()
       expect(word).toEqual('foo.bar')
@@ -125,14 +124,14 @@ describe "godef", ->
     waitsFor ->
       editor.isModified() is false
 
-    fdescribe "if there is more than one cursor", ->
+    describe "if there is more than one cursor", ->
       it "displays a warning message", ->
           editor.setCursorBufferPosition([0,0])
           editor.addCursorAtBufferPosition([1,0])
           atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
           expect(dispatch.messages?).toBe(true)
           expect(_.size(dispatch.messages)).toBe 1
-          expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningMultipleCursorsMessage)
+          expect(dispatch.messages[0].type).toBe("warning")
 
       describe "with no word under the cursor", ->
         beforeEach ->
@@ -147,7 +146,7 @@ describe "godef", ->
           atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
           expect(dispatch.messages?).toBe(true)
           expect(_.size(dispatch.messages)).toBe 1
-          expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningNotFoundMessage)
+          expect(dispatch.messages[0].type).toBe("warning")
 
       describe "with a word under the cursor", ->
         beforeEach ->

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -5,7 +5,8 @@
   - how to test for dispatch of a command?
   - how to wait for presentation of a new editor?
   - check for paths of exe and source files on Windows
-  - copy text from test file
+  - copy test text from test file instead of using string lits?
+  - deal with multiple cursors
 
  Questions for
 
@@ -20,10 +21,11 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require('temp').track()
 _ = require ("underscore-plus")
+{Subscriber} = require 'emissary'
 
 describe "godef", ->
-  [editor, editorView, dispatch, buffer, filePath, workspaceElement] = []
-  testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}"
+  [editor, editorView, dispatch, filePath, workspaceElement] = []
+  testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}\n\n"
 
   beforeEach ->
     directory = temp.mkdirSync()
@@ -44,66 +46,99 @@ describe "godef", ->
       atom.packages.activatePackage('go-plus')
 
     runs ->
-      buffer = editor.getBuffer()
-      buffer.setText testText
-      buffer.save()
       dispatch = atom.packages.getLoadedPackage('go-plus').mainModule.dispatch
       dispatch.goexecutable.detect()
 
     waitsFor ->
       dispatch.ready is true
 
+  describe "wordAtCursor (| represents cursor pos)", ->
+    godef = null
+    beforeEach ->
+      godef = dispatch.godef
+      godef.editor = editor
+
+    it "should return foo for |foo", ->
+      editor.setText("foo")
+      editor.setCursorBufferPosition([0,0])
+      expect(godef.wordAtCursor()).toEqual('foo')
+
+    it "should return foo for fo|o", ->
+      editor.setText("foo")
+      editor.setCursorBufferPosition([0,2])
+      expect(godef.wordAtCursor()).toEqual('foo')
+
+    # arguable, but easiest to implement using atom Cursor's methods
+    it "should return empty for foo|", ->
+      editor.setText("foo")
+      editor.setCursorBufferPosition([0,3])
+      expect(godef.wordAtCursor()).toEqual('')
+
+    it "should return foo.bar for !foo.bar", ->
+      editor.setText("foo.bar")
+      editor.setCursorBufferPosition([0,0])
+      expect(godef.wordAtCursor()).toEqual('foo.bar')
+
+    it "should return foo.bar for foo.ba|r", ->
+      editor.setText("foo.bar")
+      editor.setCursorBufferPosition([0,6])
+      expect(godef.wordAtCursor()).toEqual('foo.bar')
+
   describe "when go-plus is loaded", ->
     it "should have registered the golang:godef command",  ->
       currentCommands = atom.commands.findCommands({target: editorView})
-      # get name from the godef package, rather than magick'd here?
       godefCommand = (cmd for cmd in currentCommands when cmd.name is dispatch.godef.commandName)
       expect(godefCommand.length).toEqual(1)
 
   describe "when godef command is invoked", ->
       describe "with no word under the cursor", ->
+        beforeEach ->
+          editor.setText ""
+          editor.save()
+
+        waitsFor ->
+          editor.isModified() is false
+
         it "displays a warning message", ->
+          editor.setCursorBufferPosition([0,0])
           atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
           expect(dispatch.messages?).toBe(true)
           expect(_.size(dispatch.messages)).toBe 1
           expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningNotFoundMessage)
 
-        it "should not dispatch godef", ->
+        # TODO implement
+        xit "should not dispatch godef", ->
           expect(false).toBe(true)
 
       describe "with a word under the cursor", ->
-        describe "defined within the current file", ->
-          fit "should move the cursor to the definition", ->
+        beforeEach ->
+          runs ->
+            editor.setText testText
+            editor.save()
+
+          waitsFor ->
+           editor.isModified() is false
+
+        # TODO fix something async-funky making this test fail
+        xdescribe "defined within the current file", ->
+          it "should move the cursor to the definition", ->
             done = false
-            console.log "file written to #{filePath}"
-            runs ->
-              editor.setCursorBufferPosition([4,24])
-              atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
-
-              ### TODO this is the test I'm working on
-                   Here's the test impasse
-                   Currently although gotoDefinitionForWord works, the test doesn't.
-                   I think atom.commands.dispatch() is returning before the buffer
-                   cursor is moved
-                  So how to wait for presumably asynchronous dispatch call???
-
-                  One possibility is to listen for an event we set up on
-                  Godef::gotoDefinitionForWord
-                        dispatch.godef.on 'testingdone', ->
-                          console.log "I GOT IT"
-                  Possibly bad? Only emitted for test?
-                  Try the new Atom non-stringly event system:
-                    https://github.com/atom/event-kit
-                    http://blog.atom.io/2014/09/16/new-event-subscription-api.html
-              ###
-              expect(editor.getCursorBufferPosition().toArray()).toEqual([2,5])
-              # would rather compare with a Point, but always gives me a ReferenceError
+            subscription = dispatch.godef.on "#{dispatch.godef.name}-complete", ->
+              # `new Point` always results in ReferenceError (why?), hence array
+              expect(editor.getCursorBufferPosition().toArray()).toEqual([2,5]) #"testvar" decl
               done = true
+            runs ->
+              editor.setCursorBufferPosition([4,24]) # "testvar" use
+              atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
             waitsFor ->
-              done is true
+              done == true
+            runs ->
+              subscription.dispose()
 
-        describe "defined outside the current file", ->
+        # TODO implement
+        xdescribe "defined outside the current file", ->
           it "should open a new text editor", ->
+
             done = false
             runs ->
               editor.setText("notAGoKeyword")
@@ -117,6 +152,3 @@ describe "godef", ->
 
             waitsFor ->
               done is true
-
-          it "with the cursor at the definition", ->
-            expect(false).toBe(true)

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -6,9 +6,9 @@
      "Uncaught TypeError: Cannot read property 'add' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (752)
       (in dispatch::updatePane)
     No idea about this as yet
-  - Bug: opens empty file "-" when invoked on simple type names (int, string etc)
+  * Bug: opens empty file "-" when invoked on simple type names (int, string etc)
 
-  * use mapMessages (or if not, why not?)
+  - refactor godef:gotoDefinitionForWord
   - research godef "# godef: cannot parse expression: <arg>:1:1: expected operand, found 'return'"
   - thorough playing to destruction with lots of go files
     (use on a couple of days' Go programming)

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -1,7 +1,12 @@
 ###
   TODO - Essential
-  * bug: never dispose() cursor subscriptions in godef.coffee
-  - bug: "Uncaught TypeError: Cannot read property 'add' of null",
+  - BUG: 
+    "Uncaught TypeError: Cannot read property 'checkBuffer' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (583)
+      (in dispatch::triggerPipeline)
+     "Uncaught TypeError: Cannot read property 'add' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (752)
+      (in dispatch::updatePane)
+    No idea about this as yet
+
   - how to test for dispatch of a command?
   - deal with multiple cursors
   - check for paths of exe and source files on Windows?

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -7,29 +7,27 @@
       (in dispatch::updatePane)
     No idea about this as yet
 
-  * deal with multiple cursors
-  - how to test for dispatch of a command?
-  - check for paths of exe and source files on Windows?
+  * check that godef will install using go get if not exists
+  - use mapMessages
   - thorough playing to destruction with lots of go files
     (use on a couple of days' Go programming)
+  - refactor messy godef::gotoDefinitionForWord
 
   TODO - Enhancements
-  - copy test text from test file instead of using string lits?
+  - copy test text from test file instead of using string lits
   - scroll target to put the def line at top of ed pane when it's in a different file?
   - should I use mapMessages approach? I'm forking based on exitcode.
   - consider -webkit-animation: to animate the definition highlight?
 
  Questions for package maintainer
 
+  - I don't know anything about the appveyor/travis stuff
   - why function/method args sometimes, sometimes not, in brackets? (happily
     inconsistent, or is there a patter I'm not seeing?)
+    A good reason to keep consistent: f() looks a lot like f () ->
   - gofmt has a buffer existence check: `buffer = editor?.getBuffer()`
     Under what circumstances would a valid (*.go) active text editor not have a
     buffer?
-
-
-    A good reason to keep consistent: f() looks a lot like f () ->
-
  ###
 
 path = require 'path'
@@ -135,10 +133,6 @@ describe "godef", ->
           expect(_.size(dispatch.messages)).toBe 1
           expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningMultipleCursorsMessage)
 
-      it "should not dispatch godef", ->
-        expect(false).toBe(true)
-
-
       describe "with no word under the cursor", ->
         beforeEach ->
           editor.setText ""
@@ -153,10 +147,6 @@ describe "godef", ->
           expect(dispatch.messages?).toBe(true)
           expect(_.size(dispatch.messages)).toBe 1
           expect(dispatch.messages[0].msg).toBe(dispatch.godef.warningNotFoundMessage)
-
-        # TODO implement
-        xit "should not dispatch godef", ->
-          expect(false).toBe(true)
 
       describe "with a word under the cursor", ->
         beforeEach ->

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -6,9 +6,10 @@
      "Uncaught TypeError: Cannot read property 'add' of null", source: /Users/crispinb/work/code/atom/go-plus/lib/dispatch.coffee (752)
       (in dispatch::updatePane)
     No idea about this as yet
+  - Bug: opens empty file "-" when invoked on simple type names (int, string etc)
 
-  * check that godef will install using go get if not exists
-  - use mapMessages
+  * use mapMessages (or if not, why not?)
+  - research godef "# godef: cannot parse expression: <arg>:1:1: expected operand, found 'return'"
   - thorough playing to destruction with lots of go files
     (use on a couple of days' Go programming)
   - refactor messy godef::gotoDefinitionForWord

--- a/stylesheets/go-plus.less
+++ b/stylesheets/go-plus.less
@@ -42,3 +42,7 @@
   background-color: @background-color-success;
   opacity: 0.2;
 }
+
+.editor .goplus-godef-highlight .region {
+  background-color: @background-color-highlight;
+}


### PR DESCRIPTION
Adds a new command to go-plus, `golang:godef`, bound at this stage to cmd-opt-g.The behaviour is:
- if invoked on an identifier bound at package scope in the same file, jumps cursor to the (highlighted) declaration
- if invoked on an identifier bound to an identifier declared in an import package, opens the declaring file in a new tab, and puts the cursor on the (highlighted) declaration

There are some minor oddities in godef's output in some cases. I've just special-cased these, and a message panel will pop up to explain to the user why nothing appears to be happening.

This is written and tested on a mac; haven't had a chance yet to try it on any other platform.

Fixes #123.
