### PR TITLE
Update deprecated tags and use shadow DOM

### DIFF
--- a/stylesheets/go-plus.less
+++ b/stylesheets/go-plus.less
@@ -7,19 +7,23 @@
 .go-plus {
 }
 
-.editor .gutter .go-plus-error {
+atom-text-editor .gutter .go-plus-error,
+atom-text-editor::shadow .gutter .go-plus-error{
   color: @text-color-error;
 }
 
-.editor .gutter .git-line-added.go-plus-error {
+atom-text-editor .gutter .git-line-added.go-plus-error,
+atom-text-editor::shadow .gutter .git-line-added.go-plus-error {
   color: @text-color-error;
 }
 
-.editor .gutter .git-line-modified.go-plus-error {
+atom-text-editor .gutter .git-line-modified.go-plus-error,
+atom-text-editor::shadow .gutter .git-line-modified.go-plus-error {
   color: @text-color-error;
 }
 
-.editor .gutter .git-line-removed.go-plus-error {
+atom-text-editor .gutter .git-line-removed.go-plus-error,
+atom-text-editor::shadow .gutter .git-line-removed.go-plus-error {
   color: @text-color-error;
 }
 


### PR DESCRIPTION
1. ".editor" has changed  to "atom-text-editor"
2. Add support for Shadow DOM
as recomended here: https://atom.io/docs/v0.175.0/upgrading/upgrading-your-ui-theme