### PR TITLE
Switch from the editor CSS class to the atom-text-editor class

### DIFF
--- a/styles/go-plus.atom-text-editor.less
+++ b/styles/go-plus.atom-text-editor.less
@@ -7,19 +7,19 @@
 .go-plus {
 }
 
-.editor .gutter .go-plus-error {
+.atom-text-editor .gutter .go-plus-error {
   color: @text-color-error;
 }
 
-.editor .gutter .git-line-added.go-plus-error {
+.atom-text-editor .gutter .git-line-added.go-plus-error {
   color: @text-color-error;
 }
 
-.editor .gutter .git-line-modified.go-plus-error {
+.atom-text-editor .gutter .git-line-modified.go-plus-error {
   color: @text-color-error;
 }
 
-.editor .gutter .git-line-removed.go-plus-error {
+.atom-text-editor .gutter .git-line-removed.go-plus-error {
   color: @text-color-error;
 }
 


### PR DESCRIPTION
Right now the following deprecation warnings are being produced:

* Use the `atom-text-editor` tag instead of the `editor` class.
* Target the selector `:host, atom-text-editor` instead of `.editor` for shadow DOM support.