### PR TITLE
Fix absolute path detection under windows

### DIFF
--- a/lib/gobuild.coffee
+++ b/lib/gobuild.coffee
@@ -111,7 +111,7 @@ class Gobuild
       else
         file = null
         if matchLine[5]? and matchLine[5] isnt ''
-          if matchLine[5].substring(0, 1) is '/' or matchLine[5].substring(1, 2) is ':\\'
+          if path.isAbsolute(matchLine[5])
             file = matchLine[5]
           else
             file = path.join(cwd, matchLine[5])


### PR DESCRIPTION
 (was breaking go-to-error functionality)

It should have been matchLine[5].substring(1, 3)... use path.isAbsolute instead.