### PR TITLE
Ignore more types of whitespace

### DIFF
--- a/lib/go-plus.coffee
+++ b/lib/go-plus.coffee
@@ -102,6 +102,12 @@ module.exports =
       type: 'boolean'
       default: true
       order: 16
+    suppressAutocompleteCharacters:
+      title: 'Suppress Autocomplete After Specified Characters'
+      description: 'Autocomplete suggestions will not be shown after the following space delimited list of characters'
+      type: 'string'
+      default: ') ; } , :'
+      order: 17
 
   activate: (state) ->
     run = =>

--- a/lib/gocodeprovider.coffee
+++ b/lib/gocodeprovider.coffee
@@ -31,9 +31,9 @@ class GocodeProvider
       index = buffer.characterIndexForPosition(options.bufferPosition)
       offset = 'c' + index.toString()
       text = options.editor.getText()
-      switch text[index - 1]
-        when ')', ';', ':', ',', '}', ' '
-          return resolve()
+      suppressedCharacters = @dispatch.splicersplitter.splitAndSquashToArray(' ', atom.config.get('go-plus.suppressAutocompleteCharacters'))
+      # We can't include a space in a list of space delimited characters so we force it here.
+      return resolve() if text[index - 1] in (suppressedCharacters + ' ')
       quotedRange = options.editor.displayBuffer.bufferRangeForScopeAtPosition('.string.quoted', options.bufferPosition)
       return resolve() if quotedRange
 

--- a/lib/gocodeprovider.coffee
+++ b/lib/gocodeprovider.coffee
@@ -31,7 +31,9 @@ class GocodeProvider
       index = buffer.characterIndexForPosition(options.bufferPosition)
       offset = 'c' + index.toString()
       text = options.editor.getText()
-      return resolve() if text[index - 1] is ')' or text[index - 1] is ';'
+      switch text[index - 1]
+        when ')', ';', ':', ',', '}', ' '
+          return resolve()
       quotedRange = options.editor.displayBuffer.bufferRangeForScopeAtPosition('.string.quoted', options.bufferPosition)
       return resolve() if quotedRange
 


### PR DESCRIPTION
autocomplete-plus was activating on `,`, `:`, and `}`. I couldn't come up with
a reason why anyone would want to complete on those characters so I
added them to the list. Forgive me if this is bad coffeescript...

Fixes #177