### PR TITLE
Fixing and extending the autocomplete suppression

### DIFF
--- a/lib/go-plus.coffee
+++ b/lib/go-plus.coffee
@@ -105,9 +105,9 @@ module.exports =
       order: 17
     suppressAutocompleteActivationForCharacters:
       title: 'Suppress Autocomplete Activation For Characters'
-      description: 'Suggestions will not be provided when you type one of these characters.'
+      description: 'Suggestions will not be provided when you type one of these characters. Expects a comma separated list with any of the following labels \'comma\', \'space\', \'newline\' or \'tab\' and a string of any additional characters to suppress.'
       type: 'array'
-      default: [')', 'space', ';', 'comma', ':']
+      default: ['comma', 'newline', 'space', 'tab', '/\\()"\':;<>~!@#$%^&*|+=[]{}`?-']
       items:
         type: 'string'
       order: 18

--- a/lib/gocodeprovider.coffee
+++ b/lib/gocodeprovider.coffee
@@ -16,9 +16,13 @@ class GocodeProvider
       @suppressForCharacters = _.map value, (c) ->
         char = c?.trim() or ''
         char = switch
-          when char.toLowerCase() is 'space' then ' '
           when char.toLowerCase() is 'comma' then ','
+          when char.toLowerCase() is 'newline' then '\n'
+          when char.toLowerCase() is 'space' then ' '
+          when char.toLowerCase() is 'tab' then '\t'
+          else char.split ''
         return char
+      @suppressForCharacters = _.flatten(@suppressForCharacters)
       @suppressForCharacters = _.compact(@suppressForCharacters)
 
   setDispatch: (dispatch) ->


### PR DESCRIPTION
Without the `else char` in `lib/gocodeprovider.coffee` only `space` and `comma` will be added to `@suppressForCharacters`.

Next to that also added a few logical (IMO) defaults and added a way to be able to specify a newline as well.