### PR TITLE
Remove step to install autocomplete-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 ## Installing
 
-1. Install `autocomplete-plus`: `apm install autocomplete-plus` or open Atom and go to `Preferences > Packages`, search for `autocomplete-plus`, and install it
 1. Install `go-plus`: `apm install go-plus` or open Atom and go to `Preferences > Packages`, search for `go-plus`, and install it
 
 ## Overview


### PR DESCRIPTION
autocomplete-plus is bundled with Atom since 0.199.0, so this step is no longer necessary.