### PR TITLE
Automatically find Godeps and add it to GOPATH (resolve #53)

### DIFF
--- a/lib/go.coffee
+++ b/lib/go.coffee
@@ -48,17 +48,22 @@ class Go
     # Whenever we build GOPATH, go up the directory tree to identify where there
     # might be a Godeps directory. If we find it in any parent/ancestor directory,
     # add it to GOPATH.
-    goDepCheck = ""
     goDepDir = null
     if cwd?
       goDepDir = @goDepLookupCache.get(cwd)
       if goDepDir is undefined
-        cwdParts = cwd.split(path.sep)
-        for cwdPart in cwdParts
-          if cwdPart.length > 0
-            goDepCheck = goDepCheck + path.sep + cwdPart
-            if fs.existsSync(goDepCheck + path.sep + "Godeps")
-              goDepDir = goDepCheck + path.sep + "Godeps" + path.sep + "_workspace"
+        minLastSeparator = 0
+        if os.platform() is 'win32' and cwd.contains(':\\')
+          minLastSeparator = 2
+
+        goDepCheck = cwd
+        lastSeparator = cwd.lastIndexOf(path.sep)
+        while lastSeparator > minLastSeparator
+          goDepCheck = cwd.substring(0, lastSeparator)
+          if fs.existsSync(goDepCheck + path.sep + "Godeps")
+            goDepDir = goDepCheck + path.sep + "Godeps" + path.sep + "_workspace"
+            break
+          lastSeparator = goDepCheck.lastIndexOf(path.sep)
         @goDepLookupCache.set(cwd, goDepDir)
 
     if goDepDir?

--- a/lib/go.coffee
+++ b/lib/go.coffee
@@ -52,9 +52,9 @@ class Go
       cwdParts = cwd.split(path.sep)
       for cwdPart in cwdParts
         if cwdPart.length > 0
-          goDepCheck = goDepCheck+path.sep+cwdPart
-          if fs.existsSync(goDepCheck+path.sep+"Godeps")
-            goDepDir = goDepCheck+path.sep+"Godeps"+path.sep+"_workspace"
+          goDepCheck = goDepCheck + path.sep + cwdPart
+          if fs.existsSync(goDepCheck + path.sep + "Godeps")
+            goDepDir = goDepCheck + path.sep + "Godeps" + path.sep + "_workspace"
     if goDepDir?
       result = goDepDir+path.delimiter+result
 

--- a/lib/gobuild.coffee
+++ b/lib/gobuild.coffee
@@ -52,7 +52,8 @@ class Gobuild
       callback(null)
       @dispatch.displayGoInfo(false)
       return
-    gopath = go.buildgopath()
+    cwd = path.dirname(buffer.getPath())
+    gopath = go.buildgopath(cwd)
     if not gopath? or gopath is ''
       @emit(@name + '-complete', editor, saving)
       callback(null)
@@ -60,7 +61,6 @@ class Gobuild
     splitgopath = go.splitgopath()
     env = @dispatch.env()
     env['GOPATH'] = gopath
-    cwd = path.dirname(buffer.getPath())
     output = ''
     outputPath = ''
     files = []

--- a/lib/gocodeprovider.coffee
+++ b/lib/gocodeprovider.coffee
@@ -35,9 +35,10 @@ class GocodeProvider
       buffer = options.editor.getBuffer()
       return resolve() unless buffer?
 
+      cwd = path.dirname(buffer.getPath())
       go = @dispatch.goexecutable.current()
       return resolve() unless go?
-      gopath = go.buildgopath()
+      gopath = go.buildgopath(cwd)
       return resolve() if not gopath? or gopath is ''
 
       return resolve() unless options.bufferPosition
@@ -51,7 +52,6 @@ class GocodeProvider
 
       env = @dispatch.env()
       env['GOPATH'] = gopath
-      cwd = path.dirname(buffer.getPath())
       args = ['-f=json', 'autocomplete', buffer.getPath(), offset]
       configArgs = @dispatch.splicersplitter.splitAndSquashToArray(' ', atom.config.get('go-plus.gocodeArgs'))
       args = _.union(configArgs, args) if configArgs? and _.size(configArgs) > 0

--- a/lib/gocover.coffee
+++ b/lib/gocover.coffee
@@ -128,7 +128,7 @@ class Gocover
       callback(null)
       @dispatch.displayGoInfo(false)
       return
-    gopath = go.buildgopath()
+    gopath = go.buildgopath(path.dirname(buffer.getPath()))
     if not gopath? or gopath is ''
       @emit(@name + '-complete', editor, saving)
       callback(null)

--- a/lib/gofmt.coffee
+++ b/lib/gofmt.coffee
@@ -53,7 +53,7 @@ class Gofmt
       callback(null)
       @dispatch.displayGoInfo(false)
       return
-    gopath = go.buildgopath()
+    gopath = go.buildgopath(cwd)
     if not gopath? or gopath is ''
       @emit(@name + '-complete', editor, saving)
       callback(null)

--- a/lib/golint.coffee
+++ b/lib/golint.coffee
@@ -48,14 +48,14 @@ class Golint
       callback(null)
       @dispatch.displayGoInfo(false)
       return
-    gopath = go.buildgopath()
+    cwd = path.dirname(buffer.getPath())
+    gopath = go.buildgopath(cwd)
     if not gopath? or gopath is ''
       @emit(@name + '-complete', editor, saving)
       callback(null)
       return
     env = @dispatch.env()
     env['GOPATH'] = gopath
-    cwd = path.dirname(buffer.getPath())
     args = [buffer.getPath()]
     configArgs = @dispatch.splicersplitter.splitAndSquashToArray(' ', atom.config.get('go-plus.golintArgs'))
     args = _.union(configArgs, args) if configArgs? and _.size(configArgs) > 0

--- a/lib/govet.coffee
+++ b/lib/govet.coffee
@@ -48,14 +48,14 @@ class Govet
       callback(null)
       @dispatch.displayGoInfo(false)
       return
-    gopath = go.buildgopath()
+    cwd = path.dirname(buffer.getPath())
+    gopath = go.buildgopath(cwd)
     if not gopath? or gopath is ''
       @emit(@name + '-complete', editor, saving)
       callback(null)
       return
     env = @dispatch.env()
     env['GOPATH'] = gopath
-    cwd = path.dirname(buffer.getPath())
     args = @dispatch.splicersplitter.splitAndSquashToArray(' ', atom.config.get('go-plus.vetArgs'))
     args = _.union(args, [buffer.getPath()])
     cmd = @dispatch.goexecutable.current().vet()

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "event-kit": ">=0.8.1",
     "fs-plus": "2.x",
     "glob": ">=4.0.6",
+    "node-cache": ">=3.0.0",
     "temp": ">=0.8.1",
     "underscore-plus": "1.x"
   },


### PR DESCRIPTION
When using Godeps, the GOPATH needs to include <project dir>/Godeps/_workspace to access any dependencies provided by Godeps.

This change should resolve https://github.com/joefitzgerald/go-plus/issues/53