### PR TITLE
Remove autocomplete-plus install from CI scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ notifications:
     on_success: never
     on_failure: change
 
-env:
-  - APM_TEST_PACKAGES="autocomplete-plus"
-
 before_install:
   - brew update
   - if brew outdated | grep -qx go; then brew upgrade go; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,6 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - SET PATH=%LOCALAPPDATA%\atom\bin;%GOPATH%\bin;%PATH%
   - apm clean
-  - apm install autocomplete-plus
   - apm install
   - apm test
 


### PR DESCRIPTION
This package is now bundled with Atom and doesn't need to be installed separately.

Resolves the following build warning:

>The autocomplete-plus package is bundled with Atom and should not be explicitly installed.
You can run `apm uninstall autocomplete-plus` to uninstall it and then the version bundled
with Atom will be used.