### PR TITLE
updated godef package location

### DIFF
--- a/lib/goexecutable.coffee
+++ b/lib/goexecutable.coffee
@@ -219,9 +219,9 @@ class GoExecutable
         if go.godef() isnt false and not updateExistingTools
           done()
         else
-          @executor.exec(go.executable, false, gogetenv, done, ['get', '-u', 'code.google.com/p/rog-go/exp/cmd/godef'])
+          @executor.exec(go.executable, false, gogetenv, done, ['get', '-u', 'github.com/rogpeppe/godef'])
       (callback) =>
-        done = (exitcode, stdout, stderr) =>
+        done = (exitcode, stdout, stderr) ->
           callback(null)
         if go.oracle() isnt false and not updateExistingTools
           done()


### PR DESCRIPTION
The godef package has been moved to github (see http://godoc.org/code.google.com/p/rog-go/exp/cmd/godef).  This change will allow Get Missing Tools to install it.