### PR TITLE
Better godef integration: local defs, imports

### DIFF
--- a/keymaps/go-plus.cson
+++ b/keymaps/go-plus.cson
@@ -3,4 +3,6 @@
 'atom-text-editor[data-grammar="source go"]:not(.mini)':
   'ctrl-alt-c': 'golang:gocover'
   'ctrl-alt-shift-c': 'golang:cleargocover'
+  # Shouldn't these be ctrl-alt for portability?
   'alt-cmd-g': 'golang:godef'
+  'alt-cmd-shift-g': 'golang:godef-return'

--- a/lib/executor.coffee
+++ b/lib/executor.coffee
@@ -85,5 +85,5 @@ class Executor
       err.handle()
       callback(127, output, error, messages)
 
-    if input
+    if input?
       bufferedprocess.process.stdin.end(input)

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -97,7 +97,7 @@ class Godef
 
     # godef on an import returns the imported package directory with no
     # row and column information: handle this appropriately
-    if targetFilePath.length == 0 && rowNumber
+    if targetFilePath.length is 0 and rowNumber
       targetFilePath = [rowNumber, colNumber].filter((x) -> x).join(':')
       rowNumber = colNumber = undefined
 
@@ -105,7 +105,7 @@ class Godef
     p = (rawPosition) -> parseInt(rawPosition, 10) - 1
 
     filepath: targetFilePath
-    pos: if rowNumber? && colNumber? then new Point(p(rowNumber), p(colNumber))
+    pos: if rowNumber? and colNumber? then new Point(p(rowNumber), p(colNumber))
     raw: godefStdout
 
   visitLocation: (loc, callback) ->
@@ -153,7 +153,7 @@ class Godef
 
   firstGoFilePath: (dir, files) ->
     isGoSourceFile = (file) ->
-      file.endsWith('.go') && file.indexOf('_test') == -1
+      file.endsWith('.go') and file.indexOf('_test') is -1
     for file in files
       return path.join(dir, file) if isGoSourceFile(file)
     return

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -1,6 +1,9 @@
+{Point} = require('atom')
 {Emitter, Subscriber} = require('emissary')
 path = require('path')
 fs = require('fs')
+
+EditorLocationStack = require('./util/editor-location-stack')
 
 module.exports =
 class Godef
@@ -8,10 +11,13 @@ class Godef
   Emitter.includeInto(this)
 
   constructor: (@dispatch) ->
-    @commandName = "golang:godef"
+    @godefCommand = "golang:godef"
+    @returnCommand = "golang:godef-return"
     @name = 'def'
     @didCompleteNotification = "#{@name}-complete"
-    atom.commands.add 'atom-workspace', 'golang:godef': => @gotoDefinitionForWordAtCursor()
+    @godefLocationStack = new EditorLocationStack()
+    atom.commands.add 'atom-workspace', "golang:godef": => @gotoDefinitionForWordAtCursor()
+    atom.commands.add 'atom-workspace', "golang:godef-return": => @godefReturn()
     @cursorOnChangeSubscription = null
 
   destroy: ->
@@ -22,31 +28,41 @@ class Godef
     @emit('reset', @editor)
     @cursorOnChangeSubscription?.dispose()
 
+  clearReturnHistory: ->
+    @godefLocationStack.reset()
+
   # new pattern as per http://blog.atom.io/2014/09/16/new-event-subscription-api.html
   # (but so far unable to get event-kit subscriptions to work, so keeping emissary)
-  onDidComplete: (callback) =>
+  onDidComplete: (callback) ->
     @on(@didCompleteNotification, callback)
+
+  godefReturn: ->
+    @godefLocationStack.restorePreviousLocation().then =>
+      @emitDidComplete()
 
   gotoDefinitionForWordAtCursor: ->
     @editor = atom?.workspace?.getActiveTextEditor()
     done = (err, messages) =>
-      @dispatch.resetAndDisplayMessages(@editor, messages)
+      @dispatch?.resetAndDisplayMessages(@editor, messages)
 
     unless @dispatch?.isValidEditor(@editor)
-      @emit(@didCompleteNotification, @editor, false)
+      @emitDidComplete()
       return
     if @editor.hasMultipleCursors()
       @bailWithWarning('Godef only works with a single cursor', done)
       return
-    {word, range} = @wordAtCursor()
-    unless word.length > 0
-      @bailWithWarning('No word under cursor to define', done)
-      return
 
+    editorCursorOffset = (e) ->
+      e.getBuffer().characterIndexForPosition(e.getCursorBufferPosition())
+
+    offset = editorCursorOffset(@editor)
     @reset(@editor)
-    @gotoDefinitionForWord(word, done)
+    @gotoDefinitionWithParameters(['-o', offset, '-i'], @editor.getText(), done)
 
   gotoDefinitionForWord: (word, callback = -> undefined) ->
+    @gotoDefinitionWithParameters([word], undefined, callback)
+
+  gotoDefinitionWithParameters: (cmdArgs, cmdInput = undefined, callback = -> undefined) ->
     message = null
     done = (exitcode, stdout, stderr, messages) =>
       unless exitcode is 0
@@ -54,32 +70,7 @@ class Godef
         # "godef: cannot parse expression: <arg>:1:1: expected operand, found 'return'"
         @bailWithWarning(stderr, callback)
         return
-      outputs = stdout.split(':')
-      if process.platform is 'win32'
-        targetFilePath = "#{outputs[0]}:#{outputs[1]}"
-        rowNumber = outputs[2]
-        colNumber = outputs[3]
-      else
-        targetFilePath = outputs[0]
-        rowNumber = outputs[1]
-        colNumber = outputs[2]
-
-      unless fs.existsSync(targetFilePath)
-        @bailWithWarning("godef suggested a file path (\"#{targetFilePath}\") that does not exist)", callback)
-        return
-      # atom's cursors 0-based; godef uses diff-like 1-based
-      row = parseInt(rowNumber, 10) - 1
-      col = parseInt(colNumber, 10) - 1
-      if @editor.getPath() is targetFilePath
-        @editor.setCursorBufferPosition [row, col]
-        @cursorOnChangeSubscription = @highlightWordAtCursor()
-        @emit(@didCompleteNotification, @editor, false)
-        callback(null, [message])
-      else
-        atom.workspace.open(targetFilePath, {initialLine: row, initialColumn: col}).then (e) =>
-          @cursorOnChangeSubscription = @highlightWordAtCursor(atom.workspace.getActiveTextEditor())
-          @emit(@didCompleteNotification, @editor, false)
-          callback(null, [message])
+      @visitLocation(@parseGodefLocation(stdout), callback)
 
     go = @dispatch.goexecutable.current()
     cmd = go.godef()
@@ -94,9 +85,81 @@ class Godef
     env['GOPATH'] = gopath
     filePath = @editor.getPath()
     cwd = path.dirname(filePath)
-    args = ['-f', filePath, word]
+    args = ['-f', filePath, cmdArgs...]
+    @dispatch.executor.exec(cmd, cwd, env, done, args, cmdInput)
 
-    @dispatch.executor.exec(cmd, cwd, env, done, args)
+  parseGodefLocation: (godefStdout) ->
+    outputs = godefStdout.trim().split(':')
+    # Windows paths may have DriveLetter: prefix, or be UNC paths, so
+    # handle both cases:
+    [targetFilePathSegments..., rowNumber, colNumber] = outputs
+    targetFilePath = targetFilePathSegments.join(':')
+
+    # godef on an import returns the imported package directory with no
+    # row and column information: handle this appropriately
+    if targetFilePath.length == 0 && rowNumber
+      targetFilePath = [rowNumber, colNumber].filter((x) -> x).join(':')
+      rowNumber = colNumber = undefined
+
+    # atom's cursors are 0-based; godef uses diff-like 1-based
+    p = (rawPosition) -> parseInt(rawPosition, 10) - 1
+
+    filepath: targetFilePath
+    pos: if rowNumber? && colNumber? then new Point(p(rowNumber), p(colNumber))
+    raw: godefStdout
+
+  visitLocation: (loc, callback) ->
+    unless loc.filepath
+      @bailWithWarning("godef returned malformed output: #{JSON.stringify(loc.raw)}", callback)
+      return
+
+    fs.stat loc.filepath, (err, stats) =>
+      if err
+        @bailWithWarning("godef returned invalid file path: \"#{loc.filepath}\"", callback)
+        return
+
+      @godefLocationStack.pushCurrentLocation()
+      if stats.isDirectory()
+        @visitDirectory(loc, callback)
+      else
+        @visitFile(loc, callback)
+
+  visitFile: (loc, callback) ->
+    atom.workspace.open(loc.filepath).then (@editor) =>
+      if loc.pos
+        @editor.scrollToBufferPosition(loc.pos)
+        @editor.setCursorBufferPosition(loc.pos)
+        @cursorOnChangeSubscription = @highlightWordAtCursor(atom.workspace.getActiveTextEditor())
+      @emitDidComplete()
+      callback(null, [])
+
+  visitDirectory: (loc, callback) ->
+    success = (goFile) =>
+      @visitFile({filepath: goFile, raw: loc.raw}, callback)
+    failure = (err) =>
+      @bailWithWarning("godef return invalid directory #{loc.filepath}: #{err}", callback)
+    @findFirstGoFile(loc.filepath).then(success).catch(failure)
+
+  findFirstGoFile: (dir) ->
+    new Promise (resolve, reject) =>
+      fs.readdir dir, (err, files) =>
+        if err
+          reject(err)
+        goFilePath = @firstGoFilePath(dir, files.sort())
+        if goFilePath
+          resolve(goFilePath)
+        else
+          reject("#{dir} has no non-test .go file")
+
+  firstGoFilePath: (dir, files) ->
+    isGoSourceFile = (file) ->
+      file.endsWith('.go') && file.indexOf('_test') == -1
+    for file in files
+      return path.join(dir, file) if isGoSourceFile(file)
+    return
+
+  emitDidComplete: ->
+    @emit(@didCompleteNotification, @editor, false)
 
   bailWithWarning: (warning, callback) ->
     @bailWithMessage('warning', warning, callback)
@@ -112,6 +175,7 @@ class Godef
       type: type
       source: @name
     callback(null, [message])
+    @emitDidComplete()
 
   wordAtCursor: (editor = @editor) ->
     options =

--- a/lib/util/editor-location-stack.coffee
+++ b/lib/util/editor-location-stack.coffee
@@ -1,0 +1,44 @@
+doneAlready = ->
+  new Promise (resolve, reject) ->
+    resolve()
+
+module.exports =
+  class EditorLocationStack
+    constructor: (@maxSize=500) ->
+      @maxSize = 1 if @maxSize < 1
+      @stack = []
+
+    isEmpty: ->
+      not @stack.length
+
+    reset: ->
+      @stack = []
+
+    pushCurrentLocation: ->
+      editor = atom.workspace.getActiveTextEditor()
+      return unless editor
+      loc =
+        position: editor.getCursorBufferPosition()
+        file: editor.getURI()
+      return unless loc.file && loc.position?.row && loc.position?.column
+      @push(loc)
+      return
+
+    ##
+    # Returns a promise that is complete when navigation is done.
+    restorePreviousLocation: ->
+      return doneAlready() if @isEmpty()
+      lastLocation = @stack.pop()
+      atom.workspace.open(lastLocation.file).then (editor) =>
+        @moveEditorCursorTo(editor, lastLocation.position)
+
+    moveEditorCursorTo: (editor, pos) ->
+      return unless editor
+      editor.scrollToBufferPosition(pos)
+      editor.setCursorBufferPosition(pos)
+      return
+
+    push: (loc) ->
+      @stack.push(loc)
+      @stack.splice(0, @stack.length - @maxSize) if @stack.length > @maxSize
+      return

--- a/lib/util/editor-location-stack.coffee
+++ b/lib/util/editor-location-stack.coffee
@@ -4,7 +4,7 @@ doneAlready = ->
 
 module.exports =
   class EditorLocationStack
-    constructor: (@maxSize=500) ->
+    constructor: (@maxSize = 500) ->
       @maxSize = 1 if @maxSize < 1
       @stack = []
 
@@ -20,7 +20,7 @@ module.exports =
       loc =
         position: editor.getCursorBufferPosition()
         file: editor.getURI()
-      return unless loc.file && loc.position?.row && loc.position?.column
+      return unless loc.file and loc.position?.row and loc.position?.column
       @push(loc)
       return
 

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -3,10 +3,19 @@ fs = require('fs-plus')
 temp = require('temp').track()
 _ = require ("underscore-plus")
 {Subscriber} = require 'emissary'
+{Point} = require 'atom'
 
 describe "godef", ->
   [mainModule, editor, editorView, dispatch, filePath, workspaceElement] = []
-  testText = "package main\n import \"fmt\"\n var testvar = \"stringy\"\n\nfunc f(){fmt.Println( testvar )}\n\n"
+  testDisposables = []
+  testText = """package main
+                import "fmt"
+                var testvar = "stringy"
+
+                func f(){
+                  localVar := " says hi!"
+                  fmt.Println( testvar + localVar )}
+             """
 
   beforeEach ->
     # don't run any of the on-save tools
@@ -39,6 +48,65 @@ describe "godef", ->
 
     runs ->
       dispatch = mainModule.dispatch
+
+  triggerCommand = (command) ->
+    atom.commands.dispatch(workspaceElement, dispatch.godef[command])
+
+  godefDone = ->
+    new Promise (resolve, reject) ->
+      testDisposables.push(dispatch.godef.onDidComplete(resolve))
+      return
+
+  bufferTextOffset = (text, count=1, delta=0) ->
+    buffer = editor.getText()
+    index = -1
+    for i in [1..count]
+      index = buffer.indexOf(text, (if index == -1 then 0 else index + text.length))
+      break if index == -1
+    return index if index == -1
+    index + delta
+
+  offsetCursorPos = (offset) ->
+    return if offset < 0
+    editor.getBuffer().positionForCharacterIndex(offset)
+
+  bufferTextPos = (text, count=1, delta=0) ->
+    offsetCursorPos(bufferTextOffset(text, count, delta))
+
+  cursorToOffset = (offset) ->
+    return if offset == -1
+    editor.setCursorBufferPosition(offsetCursorPos(offset))
+    return
+
+  cursorToText = (text, count=1, delta=0) ->
+    cursorToOffset(bufferTextOffset(text, count, delta))
+
+  afterEach ->
+    disposable.dispose() for disposable in testDisposables
+    testDisposables = []
+
+  waitsForCommand = (command) ->
+    godefPromise = undefined
+    runs ->
+      # Create the promise before triggering the command because triggerCommand
+      # may call onDidComplete synchronously.
+      godefPromise = godefDone()
+      triggerCommand(command)
+    waitsForPromise -> godefPromise
+    return
+
+  waitsForGodef = ->
+    waitsForCommand 'godefCommand'
+
+  waitsForGodefReturn = ->
+    waitsForCommand 'returnCommand'
+
+  waitsForDispatchComplete = (action) ->
+    dispatchComplete = false
+    runs ->
+      dispatch.once 'dispatch-complete', -> dispatchComplete = true
+    runs action
+    waitsFor -> dispatchComplete
 
   describe "wordAtCursor (| represents cursor pos)", ->
     godef = null
@@ -89,90 +157,121 @@ describe "godef", ->
   describe "when go-plus is loaded", ->
     it "should have registered the golang:godef command",  ->
       currentCommands = atom.commands.findCommands({target: editorView})
-      godefCommand = (cmd for cmd in currentCommands when cmd.name is dispatch.godef.commandName)
+      godefCommand = (cmd for cmd in currentCommands when cmd.name is dispatch.godef.godefCommand)
       expect(godefCommand.length).toEqual(1)
 
   describe "when godef command is invoked", ->
-
     describe "if there is more than one cursor", ->
       it "displays a warning message", ->
-        done = false
-        runs ->
-          dispatch.once 'dispatch-complete', ->
-            done = true
+        waitsForDispatchComplete ->
           editor.setText testText
           editor.save()
-        waitsFor ->
-          done is true
-        editor.setCursorBufferPosition([0, 0])
-        editor.addCursorAtBufferPosition([1, 0])
-        atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
+        runs ->
+          editor.setCursorBufferPosition([0, 0])
+          editor.addCursorAtBufferPosition([1, 0])
 
-        expect(dispatch.messages?).toBe(true)
-        expect(_.size(dispatch.messages)).toBe 1
-        expect(dispatch.messages[0].type).toBe("warning")
+        waitsForGodef()
+
+        runs ->
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe 1
+          expect(dispatch.messages[0].type).toBe("warning")
 
     describe "with no word under the cursor", ->
-
       it "displays a warning message", ->
         editor.setCursorBufferPosition([0, 0])
-        atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
-        expect(dispatch.messages?).toBe(true)
-        expect(_.size(dispatch.messages)).toBe 1
-        expect(dispatch.messages[0].type).toBe("warning")
+        waitsForGodef()
+        runs ->
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe 1
+          expect(dispatch.messages[0].type).toBe("warning")
 
     describe "with a word under the cursor", ->
       beforeEach ->
-        done = false
-        runs ->
-          dispatch.once 'dispatch-complete', ->
-            done = true
+        waitsForDispatchComplete ->
           editor.setText testText
           editor.save()
-        waitsFor ->
-          done is true
 
       describe "defined within the current file", ->
+        beforeEach ->
+          cursorToText("testvar", 2)
+          waitsForGodef()
+
         it "should move the cursor to the definition", ->
-          done = false
-          subscription = dispatch.godef.onDidComplete ->
-            # `new Point` always results in ReferenceError (why?), hence array
-            expect(editor.getCursorBufferPosition().toArray()).toEqual([2, 5]) #"testvar" decl
-            done = true
           runs ->
-            editor.setCursorBufferPosition([4, 24]) # "testvar" use
-            atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
-          waitsFor ->
-            done is true
-          runs ->
-            subscription.dispose()
+            expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("testvar", 1))
 
         it "should create a highlight decoration of the correct class", ->
-          done = false
-          subscription = dispatch.godef.onDidComplete ->
+          runs ->
             higlightClass = 'definition'
             goPlusHighlightDecs = (d for d in editor.getHighlightDecorations() when d.getProperties()['class'] is higlightClass)
             expect(goPlusHighlightDecs.length).toBe(1)
-            done = true
-          runs ->
-            editor.setCursorBufferPosition([4, 24]) # "testvar"
-            atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
-          waitsFor ->
-            done is true
-          runs ->
-            subscription.dispose()
 
       describe "defined outside the current file", ->
         it "should open a new text editor", ->
-          done = false
-          subscription = dispatch.godef.onDidComplete ->
+          runs ->
+            # Go to the Println in fmt.Println:
+            cursorToText("fmt.Println", 1, "fmt.".length)
+          waitsForGodef()
+          runs ->
             currentEditor = atom.workspace.getActiveTextEditor()
             expect(currentEditor.getTitle()).toBe('print.go')
-            done = true
+
+      describe "defined as a local variable", ->
+        it "should jump to the local var definition", ->
           runs ->
-            editor.setCursorBufferPosition([4, 10]) # "fmt.Println"
-            atom.commands.dispatch(workspaceElement, dispatch.godef.commandName)
-          waitsFor ->
-            done is true
+            cursorToText("localVar", 2)
+          waitsForGodef()
           runs ->
-            subscription.dispose()
+            expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("localVar", 1))
+
+      describe "defined as a local import prefix", ->
+        it "should jump to the import", ->
+          runs -> cursorToText("fmt.Println")
+          waitsForGodef()
+          runs ->
+            expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("\"fmt\""))
+
+      describe "an import statement", ->
+        it "should open the first (lexicographical) .go file in the imported package", ->
+          runs -> cursorToText("\"fmt\"")
+          waitsForGodef()
+          runs ->
+            activeEditor = atom.workspace.getActiveTextEditor()
+            file = activeEditor.getURI()
+            expect(path.basename(file)).toEqual("doc.go")
+            expect(path.basename(path.dirname(file))).toEqual("fmt")
+
+  describe "when godef-return command is invoked", ->
+    beforeEach ->
+      waitsForDispatchComplete ->
+        editor.setText testText
+        editor.save()
+
+    it "will return across files to the location where godef was invoked", ->
+      runs -> cursorToText("fmt.Println", 1, "fmt.".length)
+      waitsForGodef()
+      runs ->
+        activeEditor = atom.workspace.getActiveTextEditor()
+        expect(path.basename(activeEditor.getURI())).toEqual("print.go")
+      waitsForGodefReturn()
+      runs ->
+        expect(atom.workspace.getActiveTextEditor()).toBe(editor)
+        expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("fmt.Println", 1, "fmt.".length))
+
+    it "will return within the same file to the location where godef was invoked", ->
+      runs -> cursorToText("localVar", 2)
+      waitsForGodef()
+      runs ->
+        expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("localVar", 1))
+      waitsForGodefReturn()
+      runs ->
+        expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("localVar", 2))
+
+    it 'will do nothing if the return stack is empty', ->
+      runs ->
+        dispatch.godef.clearReturnHistory()
+        cursorToText("localVar", 2)
+      waitsForGodefReturn()
+      runs ->
+        expect(editor.getCursorBufferPosition()).toEqual(bufferTextPos("localVar", 2))

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -57,28 +57,28 @@ describe "godef", ->
       testDisposables.push(dispatch.godef.onDidComplete(resolve))
       return
 
-  bufferTextOffset = (text, count=1, delta=0) ->
+  bufferTextOffset = (text, count = 1, delta = 0) ->
     buffer = editor.getText()
     index = -1
     for i in [1..count]
-      index = buffer.indexOf(text, (if index == -1 then 0 else index + text.length))
-      break if index == -1
-    return index if index == -1
+      index = buffer.indexOf(text, (if index is -1 then 0 else index + text.length))
+      break if index is -1
+    return index if index is -1
     index + delta
 
   offsetCursorPos = (offset) ->
     return if offset < 0
     editor.getBuffer().positionForCharacterIndex(offset)
 
-  bufferTextPos = (text, count=1, delta=0) ->
+  bufferTextPos = (text, count = 1, delta = 0) ->
     offsetCursorPos(bufferTextOffset(text, count, delta))
 
   cursorToOffset = (offset) ->
-    return if offset == -1
+    return if offset is -1
     editor.setCursorBufferPosition(offsetCursorPos(offset))
     return
 
-  cursorToText = (text, count=1, delta=0) ->
+  cursorToText = (text, count = 1, delta = 0) ->
     cursorToOffset(bufferTextOffset(text, count, delta))
 
   afterEach ->


### PR DESCRIPTION
go-plus' current godef integration is limited to top-level and exported names,
and does not work for method calls:

    buf := bytes.Buffer{}
    buf.Write([]byte{0x0}) // godef on Write and buf didn't work.

This is because godef was being run as:

    godef -f filebeingedited.go buf.Write

which doesn't give godef enough context to know what "buf" and "Write" are.

The fix is to run godef with the offset (-o) option to give it the offset
in the file where the cursor is, and let godef figure out what the user's
trying to navigate to.

This commit also keeps track of godef navigation on a stack and allows going
back to previous locations where godef was triggered with the godef-return
command.