### PR TITLE
godef: handle multibyte UTF-8 codepoints

### DIFF
--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -52,10 +52,12 @@ class Godef
       @bailWithWarning('Godef only works with a single cursor', done)
       return
 
-    editorCursorOffset = (e) ->
-      e.getBuffer().characterIndexForPosition(e.getCursorBufferPosition())
+    editorCursorUTF8Offset = (e) ->
+      characterOffset = e.getBuffer().characterIndexForPosition(e.getCursorBufferPosition())
+      text = e.getText().substring(0, characterOffset)
+      new Buffer(text, "utf8").length
 
-    offset = editorCursorOffset(@editor)
+    offset = editorCursorUTF8Offset(@editor)
     @reset(@editor)
     @gotoDefinitionWithParameters(['-o', offset, '-i'], @editor.getText(), done)
 

--- a/lib/godef.coffee
+++ b/lib/godef.coffee
@@ -55,7 +55,7 @@ class Godef
     editorCursorUTF8Offset = (e) ->
       characterOffset = e.getBuffer().characterIndexForPosition(e.getCursorBufferPosition())
       text = e.getText().substring(0, characterOffset)
-      new Buffer(text, "utf8").length
+      Buffer.byteLength(text, "utf8")
 
     offset = editorCursorUTF8Offset(@editor)
     @reset(@editor)

--- a/spec/godef-spec.coffee
+++ b/spec/godef-spec.coffee
@@ -13,7 +13,7 @@ describe "godef", ->
                 var testvar = "stringy"
 
                 func f(){
-                  localVar := " says hi!"
+                  localVar := " says 世界中の世界中の!"
                   fmt.Println( testvar + localVar )}
              """
 


### PR DESCRIPTION
My previous update to use godef's -o option passed in UTF-16 (Javascript
string) offsets to godef, which wants byte offsets in the source file. Give
godef the UTF-8 offset instead (since Go requires that source files must be
encoded in UTF-8).

(Switched to Buffer.byteLength to save allocating a new Buffer that's then immediately thrown away)