### PR TITLE
Add fuzzy matching to autocomplete suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The package is currently known to work on OS X, Windows (7+) and Ubuntu. CI jobs
 | Automatically Get Missing Tools         | `go-plus.getMissingTools`                   | `true`      | Run `go get -u` to retrieve any tools that are required but not currently available in the go tool directory, the PATH, or your GOPATH                                                                                                 |
 | Show Message Panel                      | `go-plus.showPanel`                         | `true`      | Show the go-plus message panel to provide information about issues with your source                                                                                                                                                    |
 | Show Message Panel When No Issues Exist | `go-plus.showPanelWhenNoIssuesExist`        | `false`     | Show the go-plus message panel even when no issues exist                                                                                                                                                                               |
+| Use Fuzzy Matching When Autocompleting  | `go-plus.fuzzAutocomplete`                  | `false`     | Use fuzzy matching for autocomplete candidates                                                                                                                                                                               |
 
 ### Detection Of Your Go Installation
 

--- a/lib/go-plus.coffee
+++ b/lib/go-plus.coffee
@@ -115,6 +115,12 @@ module.exports =
       items:
         type: 'string'
       order: 18
+    fuzzyAutocomplete:
+      title: 'Enable fuzzy autocomplete'
+      description: 'Enable fuzzy matching when autocompleting'
+      type: 'boolean'
+      default: false
+      order: 19
 
   activate: (state) ->
     run = =>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "fs-plus": "2.x",
     "glob": ">=4.0.6",
     "temp": ">=0.8.1",
-    "underscore-plus": "1.x"
+    "underscore-plus": "1.x",
+    "fuzzaldrin": "2.x"
   },
   "devDependencies": {
     "coffeelint": ">=1.8.1"


### PR DESCRIPTION
This PR adds fuzzy autocomplete matching using [fuzzaldrin](https://github.com/atom/fuzzaldrin). Fuzzy matching is disabled by default, but can be enabled using `fuzzyAutocomplete: true` in the config file.

There is room for improvement, such as ordering suggestions based on frequency of usage. Other improvements may also be possible, but my knowledge in this area is limited. This is a naive approach that simply pipes everything through fuzzaldrin.

Please note: I am rather new to coffeescript and this is my first time working on an Atom package. I'm sure there is room for improvement in my code. Feedback would be most appreciated. I'm happy to clean/alter things to make this PR acceptable.

Thank you!
