### PR TITLE
Fix #231

### DIFF
--- a/lib/gocodeprovider.coffee
+++ b/lib/gocodeprovider.coffee
@@ -46,7 +46,7 @@ class GocodeProvider
       return resolve() if index > 0 and text[index - 1] in @suppressForCharacters
       quotedRange = options.editor.displayBuffer.bufferRangeForScopeAtPosition('.string.quoted', options.bufferPosition)
       return resolve() if quotedRange
-      
+
       offset = Buffer.byteLength(text.substring(0, index), "utf8")
 
       env = @dispatch.env()
@@ -77,7 +77,7 @@ class GocodeProvider
 
   mapMessages: (data, editor, position) ->
     return [] unless data?
-    res = JSON.parse(data)
+     try res = JSON.parse(data) catch e then return []
 
     numPrefix = res[0]
     candidates = res[1]


### PR DESCRIPTION
Add try/catch to JSON parsing to prevent runtime errors.

Been having this issue for a whole now. Whenever I have a file open which isn't *.go it will periodically spam runtime errors. Atom noted that this issue was related to #231 and can be fixed by adding a safeguard to JSON parsing.