### PR TITLE
Merge gofmt back into go-plus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ install:
   - source "$NVM_DIR/nvm.sh"
   - nvm install node
   - nvm use node
+  - go get -u golang.org/x/tools/cmd/goimports
+  - go get -u github.com/sqs/goreturns
 
 script:
   - 'curl -s https://raw.githubusercontent.com/atom/ci/943a16cd32926bdfcca703f16ec6a958a2db38a5/build-package.sh | sh'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 This package adds extra functionality to Atom for the go language by installing the following packages:
 
 * [autocomplete-go](https://atom.io/packages/autocomplete-go): Autocomplete using `gocode`
-* [gofmt](https://atom.io/packages/gofmt): Formatting source using `gofmt`, `goimports`, or `goreturns`
 * [builder-go](https://atom.io/packages/builder-go): Run `go install .` and `go test -c -o {tempdir} .` to verify your code can compile and to keep gocode suggestions up to date
 * [gometalinter-linter](https://atom.io/packages/gometalinter-linter): Run a variety of linters (e.g. `golint`, `vet`, `gotype`, etc.) against your code
 * [navigator-go](https://atom.io/packages/navigator-go): Go to definition using `godef`
@@ -39,7 +38,6 @@ If you are missing any required tools, you may be prompted by [go-get](https://a
 * [`autocompletion / gocode`](https://github.com/joefitzgerald/autocomplete-go): [create issue](https://github.com/joefitzgerald/autocomplete-go/issues/new)
 * [`building`](https://github.com/joefitzgerald/builder-go): [create issue](https://github.com/joefitzgerald/builder-go/issues/new)
 * [`linting / gometalinter`](https://github.com/joefitzgerald/gometalinter-linter): [create issue](https://github.com/joefitzgerald/gometalinter-linter/issues/new)
-* [`gofmt / goimports / goreturns`](https://github.com/joefitzgerald/gofmt): [create issue](https://github.com/joefitzgerald/gofmt/issues/new)
 * [`go to definition / godef`](https://github.com/joefitzgerald/navigator-go): [create issue](https://github.com/joefitzgerald/navigator-go/issues/new)
 * [`test coverage`](https://github.com/joefitzgerald/tester-go/issues/new)
 * [`gorename`](https://github.com/zmb3/gorename): [create issue](https://github.com/zmb3/gorename/issues/new)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ skip_tags: true
 environment:
   GOPATH: c:\gopath
   GOVERSION: 1.7
-  APM_TEST_PACKAGES: environment go-config 
+  APM_TEST_PACKAGES: environment go-config
   ATOM_LINT_WITH_BUNDLED_NODE: "false"
 
   matrix:
@@ -26,6 +26,8 @@ install:
   - go version
   - go env
   - mkdir c:\gopath
+  - go get -u golang.org/x/tools/cmd/goimports
+  - go get -u github.com/sqs/goreturns
   - ps: Install-Product node 6
 
 build_script:

--- a/keymaps/go-plus.json
+++ b/keymaps/go-plus.json
@@ -1,5 +1,9 @@
 {
   "atom-workspace": {
-    "ctrl-alt-shift-g p": "golang:toggle-panel"
+    "ctrl-alt-shift-g p": "golang:toggle-panel",
+
+    "ctrl-alt-shift-g f": "golang:gofmt",
+    "ctrl-alt-shift-g i": "golang:goimports",
+    "ctrl-alt-shift-g r": "golang:goreturns"
   }
 }

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -86,7 +86,6 @@ class Formatter {
   }
 
   subscribeToSaveEvents () {
-    debugger
     this.saveSubscriptions.add(atom.workspace.observeTextEditors((editor) => {
       if (!editor || !editor.getBuffer()) {
         return

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,0 +1,333 @@
+'use babel'
+
+import {CompositeDisposable} from 'atom'
+import path from 'path'
+
+class Formatter {
+  constructor (goconfigFunc, gogetFunc) {
+    this.goget = gogetFunc
+    this.goconfig = goconfigFunc
+    this.subscriptions = new CompositeDisposable()
+    this.saveSubscriptions = new CompositeDisposable()
+    this.updatingFormatterCache = false
+    this.setToolLocations()
+    this.observeConfig()
+    this.handleCommands()
+    this.updateFormatterCache()
+  }
+
+  dispose () {
+    if (this.subscriptions) {
+      this.subscriptions.dispose()
+    }
+    this.subscriptions = null
+    if (this.saveSubscriptions) {
+      this.saveSubscriptions.dispose()
+    }
+    this.saveSubscriptions = null
+    this.goget = null
+    this.goconfig = null
+    this.formatTool = null
+    this.toolCheckComplete = null
+    this.formatterCache = null
+    this.updatingFormatterCache = null
+    this.toolLocations = null
+  }
+
+  setToolLocations () {
+    this.toolLocations = {
+      gofmt: false,
+      goimports: 'golang.org/x/tools/cmd/goimports',
+      goreturns: 'github.com/sqs/goreturns'
+    }
+  }
+
+  handleCommands () {
+    atom.project.onDidChangePaths((projectPaths) => {
+      this.updateFormatterCache()
+    })
+    this.subscriptions.add(atom.commands.add('atom-text-editor[data-grammar~="go"]', 'golang:gofmt', () => {
+      if (!this.ready() || !this.getEditor()) {
+        return
+      }
+      this.format(this.getEditor(), 'gofmt')
+    }))
+    this.subscriptions.add(atom.commands.add('atom-text-editor[data-grammar~="go"]', 'golang:goimports', () => {
+      if (!this.ready() || !this.getEditor()) {
+        return
+      }
+      this.format(this.getEditor(), 'goimports')
+    }))
+    this.subscriptions.add(atom.commands.add('atom-text-editor[data-grammar~="go"]', 'golang:goreturns', () => {
+      if (!this.ready() || !this.getEditor()) {
+        return
+      }
+      this.format(this.getEditor(), 'goreturns')
+    }))
+  }
+
+  observeConfig () {
+    this.subscriptions.add(atom.config.observe('go-plus.formatTool', (formatTool) => {
+      this.formatTool = formatTool
+      if (this.toolCheckComplete) {
+        this.toolCheckComplete[formatTool] = false
+      }
+      this.checkForTool(formatTool)
+    }))
+    this.subscriptions.add(atom.config.observe('go-plus.formatOnSave', (formatOnSave) => {
+      if (this.saveSubscriptions) {
+        this.saveSubscriptions.dispose()
+      }
+      this.saveSubscriptions = new CompositeDisposable()
+      if (formatOnSave) {
+        this.subscribeToSaveEvents()
+      }
+    }))
+  }
+
+  subscribeToSaveEvents () {
+    debugger
+    this.saveSubscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      if (!editor || !editor.getBuffer()) {
+        return
+      }
+
+      let bufferSubscriptions = new CompositeDisposable()
+      bufferSubscriptions.add(editor.getBuffer().onWillSave((filePath) => {
+        let p = editor.getPath()
+        if (filePath && filePath.path) {
+          p = filePath.path
+        }
+        this.format(editor, this.formatTool, p)
+      }))
+      bufferSubscriptions.add(editor.getBuffer().onDidDestroy(() => {
+        bufferSubscriptions.dispose()
+      }))
+      this.saveSubscriptions.add(bufferSubscriptions)
+    }))
+  }
+
+  ready () {
+    return this.goconfig && this.goconfig() && !this.updatingFormatterCache && this.formatterCache && this.formatterCache.size > 0
+  }
+
+  resetFormatterCache () {
+    this.formatterCache = null
+  }
+
+  updateFormatterCache () {
+    if (this.updatingFormatterCache) {
+      return Promise.resolve(false)
+    }
+    this.updatingFormatterCache = true
+
+    if (!this.goconfig || !this.goconfig()) {
+      this.updatingFormatterCache = false
+      return Promise.resolve(false)
+    }
+
+    let config = this.goconfig()
+    let cache = new Map()
+    let paths = atom.project.getPaths()
+    paths.push(false)
+    let promises = []
+    for (let p of paths) {
+      if (p && p.includes('://')) {
+        continue
+      }
+      for (let tool of ['gofmt', 'goimports', 'goreturns']) {
+        let key = tool + ':' + p
+        let options = { directory: p }
+        if (!p) {
+          key = tool
+          options = {}
+        }
+
+        promises.push(config.locator.findTool(tool, options).then((cmd) => {
+          if (cmd) {
+            cache.set(key, cmd)
+            return cmd
+          }
+          return false
+        }))
+      }
+    }
+    return Promise.all(promises).then(() => {
+      this.formatterCache = cache
+      this.updatingFormatterCache = false
+      return this.formatterCache
+    }).catch((e) => {
+      if (e.handle) {
+        e.handle()
+      }
+      console.log(e)
+      this.updatingFormatterCache = false
+    })
+  }
+
+  cachedToolPath (toolName, editor) {
+    if (!this.formatterCache || !toolName) {
+      return false
+    }
+
+    let p = this.projectPath(editor)
+    if (p) {
+      let key = toolName + ':' + p
+      let cmd = this.formatterCache.get(key)
+      if (cmd) {
+        return cmd
+      }
+    }
+
+    let cmd = this.formatterCache.get(toolName)
+    if (cmd) {
+      return cmd
+    }
+    return false
+  }
+
+  projectPath (editor) {
+    if (editor) {
+      let result = atom.project.relativizePath(editor.getPath())
+      if (result && result.projectPath) {
+        return result.projectPath
+      }
+    }
+    let paths = atom.project.getPaths()
+    if (paths && paths.length) {
+      for (let p of paths) {
+        if (p && !p.includes('://')) {
+          return p
+        }
+      }
+    }
+
+    return false
+  }
+
+  checkForTool (toolName = this.formatTool, options = this.getLocatorOptions()) {
+    if (!this.ready()) {
+      return
+    }
+    let config = this.goconfig()
+    return config.locator.findTool(toolName, options).then((cmd) => {
+      if (cmd) {
+        return this.updateFormatterCache().then(() => {
+          return cmd
+        })
+      }
+
+      if (!this.toolCheckComplete) {
+        this.toolCheckComplete = { }
+      }
+
+      if (!cmd && !this.toolCheckComplete[toolName]) {
+        let goget = this.goget()
+        if (!goget) {
+          return false
+        }
+        this.toolCheckComplete[toolName] = true
+
+        let packagePath = this.toolLocations[toolName]
+        if (packagePath) {
+          goget.get({
+            name: 'gofmt',
+            packageName: toolName,
+            packagePath: packagePath,
+            type: 'missing'
+          }).then(() => {
+            return this.updateFormatterCache()
+          }).catch((e) => {
+            console.log(e)
+          })
+        }
+      }
+
+      return false
+    })
+  }
+
+  getEditor () {
+    if (!atom || !atom.workspace) {
+      return
+    }
+    let editor = atom.workspace.getActiveTextEditor()
+    if (!this.isValidEditor(editor)) {
+      return
+    }
+
+    return editor
+  }
+
+  isValidEditor (editor) {
+    if (!editor || !editor.getGrammar()) {
+      return false
+    }
+
+    return editor.getGrammar().scopeName === 'source.go'
+  }
+
+  getLocatorOptions (editor = this.getEditor()) {
+    let options = {}
+    let p = this.projectPath(editor)
+    if (p) {
+      options.directory = p
+    }
+
+    return options
+  }
+
+  getExecutorOptions (editor = this.getEditor()) {
+    let o = this.getLocatorOptions(editor)
+    let options = {}
+    if (o.directory) {
+      options.cwd = o.directory
+    }
+    let config = this.goconfig()
+    if (config) {
+      options.env = config.environment(o)
+    }
+    if (!options.env) {
+      options.env = process.env
+    }
+    return options
+  }
+
+  format (editor = this.getEditor(), tool = this.formatTool, filePath) {
+    if (!this.ready() || !this.isValidEditor(editor) || !editor.getBuffer()) {
+      return
+    }
+
+    if (!filePath) {
+      filePath = editor.getPath()
+    }
+
+    let formatCmd = this.cachedToolPath(tool, editor)
+    if (!formatCmd) {
+      this.checkForTool(tool)
+      return
+    }
+
+    let cmd = formatCmd
+    let config = this.goconfig()
+    let options = this.getExecutorOptions(editor)
+    options.input = editor.getText()
+    let args = ['-e']
+    if (filePath) {
+      if (tool === 'goimports') {
+        args.push('--srcdir')
+        args.push(path.dirname(filePath))
+      }
+    }
+
+    let r = config.executor.execSync(cmd, args, options)
+    if (r.stderr && r.stderr.trim() !== '') {
+      console.log('gofmt: (stderr) ' + r.stderr)
+      return
+    }
+    if (r.exitcode === 0) {
+      editor.getBuffer().setTextViaDiff(r.stdout)
+    }
+  }
+}
+export {Formatter}

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -67,14 +67,14 @@ class Formatter {
   }
 
   observeConfig () {
-    this.subscriptions.add(atom.config.observe('go-plus.formatTool', (formatTool) => {
+    this.subscriptions.add(atom.config.observe('go-plus.gofmt.formatTool', (formatTool) => {
       this.formatTool = formatTool
       if (this.toolCheckComplete) {
         this.toolCheckComplete[formatTool] = false
       }
       this.checkForTool(formatTool)
     }))
-    this.subscriptions.add(atom.config.observe('go-plus.formatOnSave', (formatOnSave) => {
+    this.subscriptions.add(atom.config.observe('go-plus.gofmt.formatOnSave', (formatOnSave) => {
       if (this.saveSubscriptions) {
         this.saveSubscriptions.dispose()
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,7 @@ export default {
     this.subscriptions.add(this.getPanelManager().registerViewProvider(GoInformationView, goInformation))
 
     this.getFormatter()
+    this.uninstallOldPackages()
   },
 
   deactivate () {
@@ -45,6 +46,31 @@ export default {
     this.dependenciesInstalled = null
     this.toolRegistered = null
     this.formatter = null
+  },
+
+  uninstallOldPackages () {
+    // remove old packages that have been merged into go-plus
+    let pkgs = [ 'gofmt' ]
+    for (let pkg of pkgs) {
+      let p = atom.packages.getLoadedPackage(pkg)
+      if (!p) {
+        continue
+      }
+      console.log(`removing package ${pkg}`)
+      atom.packages.activatePackage('settings-view').then((pack) => {
+        if (pack && pack.mainModule) {
+          let settingsview = pack.mainModule.createSettingsView({uri: pack.mainModule.configUri})
+          settingsview.packageManager.uninstall({name: pkg}, (error) => {
+            if (!error) {
+              console.log(`the ${pkg} package has been uninstalled`)
+              atom.notifications.addInfo(`Removed the ${pkg} package, which is now provided by go-plus`)
+            } else {
+              console.log(error)
+            }
+          })
+        }
+      })
+    }
   },
 
   getPanelManager () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,7 @@ import {CompositeDisposable} from 'atom'
 import GoInformationView from './components/go-information-view'
 import {GoInformation} from './go-information'
 import {PanelManager} from './panel-manager'
+import {Formatter} from './formatter'
 
 export default {
   dependenciesInstalled: null,
@@ -11,6 +12,8 @@ export default {
   panelManager: null,
   statusBar: null,
   subscriptions: null,
+  toolRegistered: null,
+  formatter: null,
 
   activate () {
     this.subscriptions = new CompositeDisposable()
@@ -27,6 +30,8 @@ export default {
     })
     this.subscriptions.add(goInformation)
     this.subscriptions.add(this.getPanelManager().registerViewProvider(GoInformationView, goInformation))
+
+    this.getFormatter()
   },
 
   deactivate () {
@@ -38,6 +43,8 @@ export default {
     this.goconfig = null
     this.panelManager = null
     this.dependenciesInstalled = null
+    this.toolRegistered = null
+    this.formatter = null
   },
 
   getPanelManager () {
@@ -65,6 +72,24 @@ export default {
     return false
   },
 
+  getGoget () {
+    if (this.goget) {
+      return this.goget
+    }
+    return false
+  },
+
+  getFormatter () {
+    if (this.formatter) {
+      return this.formatter
+    }
+    this.formatter = new Formatter(
+      () => { return this.getGoconfig() },
+      () => { return this.getGoget() })
+    this.subscriptions.add(this.formatter)
+    return this.formatter
+  },
+
   consumeStatusBar (service) {
     this.statusBar = service
     this.getPanelManager().showStatusBar()
@@ -81,5 +106,22 @@ export default {
 
   consumeGoconfig (service) {
     this.goconfig = service
+    if (this.formatter) {
+      this.formatter.updateFormatterCache()
+    }
+  },
+
+  consumeGoget (service) {
+    this.goget = service
+    this.registerTools()
+  },
+
+  registerTools () {
+    if (this.toolRegistered || !this.goget) {
+      return
+    }
+    this.subscriptions.add(this.goget.register('golang.org/x/tools/cmd/goimports'))
+    this.subscriptions.add(this.goget.register('github.com/sqs/goreturns'))
+    this.toolRegistered = true
   }
 }

--- a/menus/go-plus.json
+++ b/menus/go-plus.json
@@ -1,0 +1,42 @@
+{
+  "context-menu": {
+    "atom-text-editor[data-grammar~=\"go\"]:not([mini])": [
+      {
+        "label": "Run gofmt",
+        "command": "golang:gofmt"
+      },
+      {
+        "label": "Run goimports",
+        "command": "golang:goimports"
+      },
+      {
+        "label": "Run goreturns",
+        "command": "golang:goreturns"
+      }
+    ]
+  },
+  "menu": [
+    {
+      "label": "Packages",
+      "submenu": [
+        {
+          "label": "Go",
+          "submenu": [
+            {
+              "label": "Format With gofmt",
+              "command": "golang:gofmt"
+            },
+            {
+              "label": "Format With goimports",
+              "command": "golang:goimports"
+            },
+            {
+              "label": "Format With goreturns",
+              "command": "golang:goreturns"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -108,24 +108,30 @@
       "default": "15vh",
       "order": 3
     },
-    "formatOnSave": {
-      "title": "Run Format Tool On Save",
-      "description": "Run the configured format tool each time a file is saved",
-      "type": "boolean",
-      "default": true,
-      "order": 4
-    },
-    "formatTool": {
-      "title": "Format Tool",
-      "description": "Choose one: goimports, goreturns, or gofmt",
-      "type": "string",
-      "default": "goimports",
-      "enum": [
-        "goimports",
-        "goreturns",
-        "gofmt"
-      ],
-      "order": 5
+    "gofmt": {
+      "title": "gofmt",
+      "type": "object",
+      "properties": {
+        "formatOnSave": {
+          "title": "Run Format Tool On Save",
+          "description": "Run the configured format tool each time a file is saved",
+          "type": "boolean",
+          "default": true,
+          "order": 1
+        },
+        "formatTool": {
+          "title": "Format Tool",
+          "description": "Choose one: goimports, goreturns, or gofmt",
+          "type": "string",
+          "default": "goimports",
+          "enum": [
+            "goimports",
+            "goreturns",
+            "gofmt"
+          ],
+          "order": 2
+        }
+      }
     }
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-plus",
-  "description": "Makes working with go in Atom awesome.",
+  "description": "Makes working with Go in Atom awesome.",
   "keywords": [
     "go",
     "golang",
@@ -38,7 +38,8 @@
     "etch-octicon": "^0.0.4"
   },
   "devDependencies": {
-    "standard": "^8.3.0"
+    "standard": "^8.3.0",
+    "temp": "^0.8.3"
   },
   "package-deps": [
     "go-config",
@@ -46,7 +47,6 @@
     "gometalinter-linter",
     "autocomplete-go",
     "navigator-go",
-    "gofmt",
     "tester-go",
     "gorename",
     "builder-go",
@@ -67,6 +67,11 @@
     "go-plus.view": {
       "versions": {
         "0.1.0": "consumeViewProvider"
+      }
+    },
+    "go-get": {
+      "versions": {
+        "2.0.0": "consumeGoget"
       }
     }
   },
@@ -102,6 +107,25 @@
       "type": "string",
       "default": "15vh",
       "order": 3
+    },
+    "formatOnSave": {
+      "title": "Run Format Tool On Save",
+      "description": "Run the configured format tool each time a file is saved",
+      "type": "boolean",
+      "default": true,
+      "order": 4
+    },
+    "formatTool": {
+      "title": "Format Tool",
+      "description": "Choose one: goimports, goreturns, or gofmt",
+      "type": "string",
+      "default": "goimports",
+      "enum": [
+        "goimports",
+        "goreturns",
+        "gofmt"
+      ],
+      "order": 5
     }
   },
   "standard": {

--- a/spec/fixtures/gofmt.go
+++ b/spec/fixtures/gofmt.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/spec/formatter-spec.js
+++ b/spec/formatter-spec.js
@@ -1,0 +1,377 @@
+'use babel'
+/* eslint-env jasmine */
+
+import fs from 'fs'
+import path from 'path'
+import temp from 'temp'
+
+let nl = '\n'
+
+describe('formatter', () => {
+  let mainModule = null
+  let formatter = null
+
+  beforeEach(() => {
+    temp.track()
+    atom.config.set('go-plus.formatOnSave', false)
+    atom.config.set('editor.defaultLineEnding', 'LF')
+
+    waitsForPromise(() => {
+      return atom.packages.activatePackage('go-config').then(() => {
+        return atom.packages.activatePackage('language-go')
+      }).then(() => {
+        return atom.packages.activatePackage('go-plus')
+      }).then((pack) => {
+        mainModule = pack.mainModule
+      })
+    })
+
+    waitsFor(() => {
+      return mainModule.goconfig
+    })
+
+    waitsFor(() => {
+      formatter = mainModule.getFormatter()
+      return formatter
+    })
+
+    waitsFor(() => {
+      return formatter.ready()
+    })
+  })
+
+  describe('when a simple file is opened', () => {
+    let editor
+    let filePath
+    let saveSubscription
+    let actual
+
+    beforeEach(() => {
+      let directory = fs.realpathSync(temp.mkdirSync())
+      atom.project.setPaths([directory])
+      filePath = path.join(directory, 'gofmt.go')
+      fs.writeFileSync(filePath, '')
+      waitsForPromise(() => {
+        return atom.workspace.open(filePath).then((e) => {
+          editor = e
+          saveSubscription = e.onDidSave(() => {
+            actual = e.getText()
+          })
+        })
+      })
+    })
+
+    afterEach(() => {
+      if (saveSubscription) {
+        saveSubscription.dispose()
+      }
+
+      actual = undefined
+    })
+
+    describe('when format on save is disabled and gofmt is the tool', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.formatOnSave', false)
+        formatter.resetFormatterCache()
+        formatter.updateFormatterCache()
+        atom.config.set('go-plus.formatTool', 'gofmt')
+        waitsFor(() => {
+          return formatter.ready()
+        })
+      })
+
+      it('does not format the file on save', () => {
+        let text = 'package main' + nl + nl + 'func main()  {' + nl + '}' + nl
+        let expected = text
+        let formatted = 'package main' + nl + nl + 'func main() {' + nl + '}' + nl
+
+        runs(() => {
+          let buffer = editor.getBuffer()
+          buffer.setText(text)
+          buffer.save()
+        })
+
+        waitsFor(() => { return actual })
+
+        runs(() => {
+          expect(actual).toBe(expected)
+          expect(actual).not.toBe(formatted)
+        })
+      })
+
+      it('formats the file on command', () => {
+        let text = 'package main' + nl + nl + 'func main()  {' + nl + '}' + nl
+        let unformatted = text
+        let formatted = 'package main' + nl + nl + 'func main() {' + nl + '}' + nl
+
+        runs(() => {
+          let buffer = editor.getBuffer()
+          buffer.setText(text)
+          buffer.save()
+        })
+
+        waitsFor(() => {
+          return actual
+        })
+
+        runs(() => {
+          expect(actual).toBe(unformatted)
+          expect(actual).not.toBe(formatted)
+          let target = atom.views.getView(editor)
+          atom.commands.dispatch(target, 'golang:gofmt')
+        })
+
+        runs(() => {
+          expect(editor.getText()).toBe(formatted)
+        })
+      })
+    })
+
+    describe('when format on save is enabled and gofmt is the tool', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.formatOnSave', true)
+        formatter.resetFormatterCache()
+        formatter.updateFormatterCache()
+        atom.config.set('go-plus.formatTool', 'gofmt')
+        waitsFor(() => {
+          return formatter.ready()
+        })
+      })
+
+      it('formats the file on save', () => {
+        let text = 'package main' + nl + nl + 'func main()  {' + nl + '}' + nl
+        let expected = 'package main' + nl + nl + 'func main() {' + nl + '}' + nl
+
+        runs(() => {
+          let buffer = editor.getBuffer()
+          buffer.setText(text)
+          buffer.save()
+        })
+
+        waitsFor(() => {
+          return actual
+        })
+
+        runs(() => {
+          expect(actual).toBe(expected)
+        })
+      })
+    })
+
+    describe('when format on save is enabled and goimports is the tool', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.formatOnSave', true)
+        formatter.resetFormatterCache()
+        formatter.updateFormatterCache()
+        atom.config.set('go-plus.formatTool', 'goimports')
+        waitsFor(() => {
+          return formatter.ready()
+        })
+      })
+
+      it('formats the file on save', () => {
+        let text = 'package main' + nl + nl + 'func main()  {' + nl + '}' + nl
+        let expected = 'package main' + nl + nl + 'func main() {' + nl + '}' + nl
+
+        runs(() => {
+          let buffer = editor.getBuffer()
+          buffer.setText(text)
+          buffer.save()
+        })
+
+        waitsFor(() => {
+          return actual
+        })
+
+        runs(() => {
+          expect(actual).toBe(expected)
+        })
+      })
+    })
+
+    describe('when format on save is enabled and goreturns is the tool', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.formatOnSave', true)
+        formatter.resetFormatterCache()
+        formatter.updateFormatterCache()
+        atom.config.set('go-plus.formatTool', 'goreturns')
+        waitsFor(() => {
+          return formatter.ready()
+        })
+      })
+
+      it('formats the file on save', () => {
+        let text = 'package main' + nl + nl + 'func main()  {' + nl + '}' + nl
+        let expected = 'package main' + nl + nl + 'func main() {' + nl + '}' + nl
+
+        runs(() => {
+          let buffer = editor.getBuffer()
+          buffer.setText(text)
+          buffer.save()
+        })
+
+        waitsFor(() => {
+          return actual
+        })
+
+        runs(() => {
+          expect(actual).toBe(expected)
+        })
+      })
+    })
+  })
+})
+
+/*
+path = require('path')
+fs = require('fs-plus')
+temp = require('temp').track()
+_ = require('lodash')
+AtomConfig = require('./util/atomconfig')
+
+describe 'format', ->
+  [mainModule, editor, dispatch, buffer, filePath] = []
+
+  beforeEach ->
+    atomconfig = new AtomConfig()
+    atomconfig.allfunctionalitydisabled()
+    directory = temp.mkdirSync()
+    atom.project.setPaths(directory)
+    filePath = path.join(directory, 'go-plus.go')
+    fs.writeFileSync(filePath, '')
+    jasmine.unspy(window, 'setTimeout')
+
+    waitsForPromise -> atom.workspace.open(filePath).then (e) ->
+      editor = e
+      buffer = editor.getBuffer()
+
+    waitsForPromise ->
+      atom.packages.activatePackage('language-go')
+
+    waitsForPromise -> atom.packages.activatePackage('go-plus').then (g) ->
+      mainModule = g.mainModule
+
+    waitsFor ->
+      mainModule.dispatch?.ready
+
+    runs ->
+      dispatch = mainModule.dispatch
+
+  describe 'when format on save is enabled', ->
+    beforeEach ->
+      atom.config.set('go-plus.formatOnSave', true)
+
+    it 'reformats the file', ->
+      done = false
+      runs ->
+        dispatch.once 'dispatch-complete', ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nfunc main() {\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(0)
+          done = true
+        buffer.setText('package main\n\nfunc main()  {\n}\n')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+    it 'reformats the file after multiple saves', ->
+      done = false
+      displayDone = false
+
+      runs ->
+        dispatch.once 'dispatch-complete', ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nfunc main() {\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(0)
+          done = true
+        dispatch.once 'display-complete', ->
+          displayDone = true
+        buffer.setText('package main\n\nfunc main()  {\n}\n')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+      waitsFor ->
+        displayDone is true
+
+      runs ->
+        done = false
+        dispatch.once 'dispatch-complete', ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nfunc main() {\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(0)
+          done = true
+        buffer.setText('package main\n\nfunc main()  {\n}\n')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+    it 'collects errors when the input is invalid', ->
+      done = false
+      runs ->
+        dispatch.once 'dispatch-complete', (editor) ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nfunc main(!)  {\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(1)
+          expect(dispatch.messages[0].column).toBe('11')
+          expect(dispatch.messages[0].line).toBe('3')
+          expect(dispatch.messages[0].msg).toBe('expected type, found \'!\'')
+          done = true
+        buffer.setText('package main\n\nfunc main(!)  {\n}\n')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+    it 'uses goimports to reorganize imports if enabled', ->
+      done = false
+      runs ->
+        atom.config.set('go-plus.formatTool', 'goimports')
+        dispatch.once 'dispatch-complete', ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("Hello, 世界")\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(0)
+          done = true
+        buffer.setText('package main\n\nfunc main()  {\n\tfmt.Println("Hello, 世界")\n}\n')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+    it 'uses goreturns to handle returns if enabled', ->
+      done = false
+      runs ->
+        atom.config.set('go-plus.formatTool', 'goreturns')
+        dispatch.once 'dispatch-complete', ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package demo\n\nimport "errors"\n\nfunc F() (string, int, error) {\n\treturn "", 0, errors.New("foo")\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(0)
+          done = true
+        buffer.setText('package demo\n\nfunc F() (string, int, error)     {\nreturn errors.New("foo") }')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+  describe 'when format on save is disabled', ->
+    beforeEach ->
+      atom.config.set('go-plus.formatOnSave', false)
+
+    it 'does not reformat the file', ->
+      done = false
+      runs ->
+        dispatch.once 'dispatch-complete', ->
+          expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nfunc main()  {\n}\n')
+          expect(dispatch.messages?).toBe(true)
+          expect(_.size(dispatch.messages)).toBe(0)
+          done = true
+        buffer.setText('package main\n\nfunc main()  {\n}\n')
+        buffer.save()
+
+      waitsFor ->
+        done is true
+
+*/

--- a/spec/formatter-spec.js
+++ b/spec/formatter-spec.js
@@ -13,7 +13,7 @@ describe('formatter', () => {
 
   beforeEach(() => {
     temp.track()
-    atom.config.set('go-plus.formatOnSave', false)
+    atom.config.set('go-plus.gofmt.formatOnSave', false)
     atom.config.set('editor.defaultLineEnding', 'LF')
 
     waitsForPromise(() => {
@@ -71,10 +71,10 @@ describe('formatter', () => {
 
     describe('when format on save is disabled and gofmt is the tool', () => {
       beforeEach(() => {
-        atom.config.set('go-plus.formatOnSave', false)
+        atom.config.set('go-plus.gofmt.formatOnSave', false)
         formatter.resetFormatterCache()
         formatter.updateFormatterCache()
-        atom.config.set('go-plus.formatTool', 'gofmt')
+        atom.config.set('go-plus.gofmt.formatTool', 'gofmt')
         waitsFor(() => {
           return formatter.ready()
         })
@@ -129,10 +129,10 @@ describe('formatter', () => {
 
     describe('when format on save is enabled and gofmt is the tool', () => {
       beforeEach(() => {
-        atom.config.set('go-plus.formatOnSave', true)
+        atom.config.set('go-plus.gofmt.formatOnSave', true)
         formatter.resetFormatterCache()
         formatter.updateFormatterCache()
-        atom.config.set('go-plus.formatTool', 'gofmt')
+        atom.config.set('go-plus.gofmt.formatTool', 'gofmt')
         waitsFor(() => {
           return formatter.ready()
         })
@@ -160,10 +160,10 @@ describe('formatter', () => {
 
     describe('when format on save is enabled and goimports is the tool', () => {
       beforeEach(() => {
-        atom.config.set('go-plus.formatOnSave', true)
+        atom.config.set('go-plus.gofmt.formatOnSave', true)
         formatter.resetFormatterCache()
         formatter.updateFormatterCache()
-        atom.config.set('go-plus.formatTool', 'goimports')
+        atom.config.set('go-plus.gofmt.formatTool', 'goimports')
         waitsFor(() => {
           return formatter.ready()
         })
@@ -191,10 +191,10 @@ describe('formatter', () => {
 
     describe('when format on save is enabled and goreturns is the tool', () => {
       beforeEach(() => {
-        atom.config.set('go-plus.formatOnSave', true)
+        atom.config.set('go-plus.gofmt.formatOnSave', true)
         formatter.resetFormatterCache()
         formatter.updateFormatterCache()
-        atom.config.set('go-plus.formatTool', 'goreturns')
+        atom.config.set('go-plus.gofmt.formatTool', 'goreturns')
         waitsFor(() => {
           return formatter.ready()
         })
@@ -259,7 +259,7 @@ describe 'format', ->
 
   describe 'when format on save is enabled', ->
     beforeEach ->
-      atom.config.set('go-plus.formatOnSave', true)
+      atom.config.set('go-plus.gofmt.formatOnSave', true)
 
     it 'reformats the file', ->
       done = false
@@ -329,7 +329,7 @@ describe 'format', ->
     it 'uses goimports to reorganize imports if enabled', ->
       done = false
       runs ->
-        atom.config.set('go-plus.formatTool', 'goimports')
+        atom.config.set('go-plus.gofmt.formatTool', 'goimports')
         dispatch.once 'dispatch-complete', ->
           expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package main\n\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("Hello, 世界")\n}\n')
           expect(dispatch.messages?).toBe(true)
@@ -344,7 +344,7 @@ describe 'format', ->
     it 'uses goreturns to handle returns if enabled', ->
       done = false
       runs ->
-        atom.config.set('go-plus.formatTool', 'goreturns')
+        atom.config.set('go-plus.gofmt.formatTool', 'goreturns')
         dispatch.once 'dispatch-complete', ->
           expect(fs.readFileSync(filePath, {encoding: 'utf8'})).toBe('package demo\n\nimport "errors"\n\nfunc F() (string, int, error) {\n\treturn "", 0, errors.New("foo")\n}\n')
           expect(dispatch.messages?).toBe(true)
@@ -358,7 +358,7 @@ describe 'format', ->
 
   describe 'when format on save is disabled', ->
     beforeEach ->
-      atom.config.set('go-plus.formatOnSave', false)
+      atom.config.set('go-plus.gofmt.formatOnSave', false)
 
     it 'does not reformat the file', ->
       done = false


### PR DESCRIPTION
- [x] Add formatter and specs from gofmt package
- [x] Add menu items and keymaps
- [x] Group gofmt config settings under a separate object
- [x] Add code to remove the gofmt package which will no longer be necessary