### PR TITLE
Consolidate builder-go into go-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,28 @@
 This package adds extra functionality to Atom for the go language by installing the following packages:
 
 * [autocomplete-go](https://atom.io/packages/autocomplete-go): Autocomplete using `gocode`
-* [builder-go](https://atom.io/packages/builder-go): Run `go install .` and `go test -c -o {tempdir} .` to verify your code can compile and to keep gocode suggestions up to date
 * [gometalinter-linter](https://atom.io/packages/gometalinter-linter): Run a variety of linters (e.g. `golint`, `vet`, `gotype`, etc.) against your code
 * [navigator-go](https://atom.io/packages/navigator-go): Go to definition using `godef`
 * [tester-go](https://atom.io/packages/tester-go): Display test coverage using `go test -coverprofile`
 * [gorename](https://atom.io/packages/gorename): Rename the symbol under your cursor using `gorename`
 * [go-debug](https://atom.io/packages/go-debug): Debug your package / tests using [`delve`](https://github.com/derekparker/delve)
 * [godoc](https://atom.io/packages/godoc): Display documentation for identifiers in source code using [`gogetdoc`](https://github.com/zmb3/gogetdoc)
+
+## Builds
+
+### How Are The Builds Performed?
+
+The following commands are run for the directory of the current file:
+* `go install .` (for normal `.go` files)
+* `go test -o {tmpdir} -c .` (for `_test.go` files)
+
+### Why Are You Running `go install` Instead Of `go build`?
+
+`gocode` (and a few other tools, like `gotype`) work on `.a` files (i.e. the package object archive), and the way to keep these up to date is to run `go install` periodically. This ensures your autocomplete suggestions are kept up to date without having to resort to `gocode set autobuild true` :tada:.
+
+### But What About `gb`?
+
+I'm open to suggestions for detecting a package which is built with gb; please feel free to submit a pull request that detects a gb package without any explicit configuration and runs it.
 
 ## Platforms
 
@@ -36,7 +51,6 @@ If you are missing any required tools, you may be prompted by [go-get](https://a
 
 * [`runtime detection`](https://github.com/joefitzgerald/go-config): [create issue](https://github.com/joefitzgerald/go-config/issues/new)
 * [`autocompletion / gocode`](https://github.com/joefitzgerald/autocomplete-go): [create issue](https://github.com/joefitzgerald/autocomplete-go/issues/new)
-* [`building`](https://github.com/joefitzgerald/builder-go): [create issue](https://github.com/joefitzgerald/builder-go/issues/new)
 * [`linting / gometalinter`](https://github.com/joefitzgerald/gometalinter-linter): [create issue](https://github.com/joefitzgerald/gometalinter-linter/issues/new)
 * [`go to definition / godef`](https://github.com/joefitzgerald/navigator-go): [create issue](https://github.com/joefitzgerald/navigator-go/issues/new)
 * [`test coverage`](https://github.com/joefitzgerald/tester-go/issues/new)

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,0 +1,221 @@
+'use babel'
+
+import {CompositeDisposable} from 'atom'
+import fs from 'fs'
+import path from 'path'
+import rimraf from 'rimraf'
+import temp from 'temp'
+
+class Builder {
+  constructor (goconfigFunc) {
+    this.goconfig = goconfigFunc
+    this.subscriptions = new CompositeDisposable()
+
+    this.name = 'go build'
+    this.grammarScopes = ['source.go']
+    this.scope = 'project'
+    this.lintOnFly = false
+    temp.track()
+  }
+
+  dispose () {
+    if (this.subscriptions) {
+      this.subscriptions.dispose()
+    }
+    this.subscriptions = null
+    this.goconfig = null
+    this.name = null
+    this.grammarScopes = null
+    this.lintOnFly = null
+  }
+
+  ready () {
+    if (!this.goconfig) {
+      return false
+    }
+    let config = this.goconfig()
+    if (!config) {
+      return false
+    }
+
+    return true
+  }
+
+  lint (editor) {
+    if (!this.ready() || !editor) {
+      return []
+    }
+    let p = editor.getPath()
+    if (!p) {
+      return []
+    }
+    return Promise.resolve().then(() => {
+      let config = this.goconfig()
+      let options = this.getLocatorOptions(editor)
+      return config.locator.findTool('go', options).then((cmd) => {
+        if (!cmd) {
+          return []
+        }
+
+        let options = this.getExecutorOptions(editor)
+        let buildPromise = this.lintInstall(cmd, options)
+
+        let testPromise = Promise.resolve({ output: '', linterName: 'test' })
+        if (this.hasTests(p)) {
+          testPromise = this.lintTest(cmd, options)
+        }
+
+        return Promise.all([buildPromise, testPromise]).then((results) => this.getMessages(results, options.cwd))
+      })
+    }).catch((error) => {
+      if (error.handle) {
+        error.handle()
+      }
+      console.log(error)
+      return []
+    })
+  }
+
+  getMessages (results, cwd) {
+    let messages = []
+    for (let { output, linterName } of results) {
+      let newMessages = this.mapMessages(output, cwd, linterName)
+      for (let newMessage of newMessages) {
+        if (!messages.some((message) => this.messageEquals(newMessage, message))) {
+          messages = messages.concat(newMessage)
+        }
+      }
+    }
+    // add the "(<name>)" postfix to each message
+    for (let message of messages) {
+      message.text += ' (' + message.name + ')'
+    }
+    return messages
+  }
+
+  messageEquals (m1, m2) {
+    return m1.filePath === m2.filePath &&
+      m1.row === m2.row &&
+      m1.text === m2.text &&
+      JSON.stringify(m1.range) === JSON.stringify(m2.range)
+  }
+
+  lintInstall (cmd, options) {
+    let buildArgs = ['install', '.']
+    return this.goconfig().executor.exec(cmd, buildArgs, options).then((r) => {
+      if (r.stdout && r.stdout.trim() !== '') {
+        console.log('builder-go: (stdout) ' + r.stdout)
+      }
+      return { output: r.stderr.trim(), linterName: 'build' }
+    }).catch((e) => {
+      console.log(e)
+      return { output: '', linterName: 'build' }
+    })
+  }
+
+  lintTest (cmd, options) {
+    let tempdir = fs.realpathSync(temp.mkdirSync())
+    let testArgs = ['test', '-c', '-o', tempdir, '.']
+    return this.goconfig().executor.exec(cmd, testArgs, options).then((r) => {
+      if (r.stdout && r.stdout.trim() !== '') {
+        console.log('builder-go: (stdout) ' + r.stdout)
+      }
+      rimraf(tempdir, (e) => {
+        if (e) {
+          if (e.handle) {
+            e.handle()
+          }
+          console.log(e)
+        }
+      })
+      return { output: r.stderr.trim(), linterName: 'test' }
+    }).catch((e) => {
+      console.log(e)
+      return { output: '', linterName: 'test' }
+    })
+  }
+
+  getLocatorOptions (editor = atom.workspace.getActiveTextEditor()) {
+    let options = {}
+    if (editor) {
+      options.file = editor.getPath()
+      options.directory = path.dirname(editor.getPath())
+    }
+    if (!options.directory && atom.project.paths.length) {
+      options.directory = atom.project.paths[0]
+    }
+
+    return options
+  }
+
+  getExecutorOptions (editor = atom.workspace.getActiveTextEditor()) {
+    let o = this.getLocatorOptions(editor)
+    let options = {}
+    if (o.directory) {
+      options.cwd = o.directory
+    }
+    let config = this.goconfig()
+    if (config) {
+      options.env = config.environment(o)
+    }
+    if (!options.env) {
+      options.env = process.env
+    }
+    return options
+  }
+
+  mapMessages (data, cwd, linterName) {
+    let pattern = /^((#)\s(.*)?)|((.*?):(\d*?):((\d*?):)?\s((.*)?((\n\t.*)+)?))/img
+    let messages = []
+    let match
+    while ((match = pattern.exec(data)) !== null) {
+      let message = this.extractMessage(match, cwd, linterName)
+      if (message) {
+        messages.push(message)
+      }
+    }
+    return messages
+  }
+
+  extractMessage (line, cwd, linterName) {
+    if (!line) {
+      return
+    }
+    if (line[2] && line[2] === '#') {
+      // Found A Package Indicator, Skip For Now
+      return
+    }
+    let filePath
+    if (line[5] && line[5] !== '') {
+      if (path.isAbsolute(line[5])) {
+        filePath = line[5]
+      } else {
+        filePath = path.join(cwd, line[5])
+      }
+    }
+    let row = line[6]
+    let column = line[8]
+    let text = line[9]
+    let range
+    if (column && column >= 0) {
+      range = [[row - 1, column - 1], [row - 1, 1000]]
+    } else {
+      range = [[row - 1, 0], [row - 1, 1000]]
+    }
+    return { name: linterName, type: 'Error', row, column, text, filePath, range }
+  }
+
+  hasTests (p) {
+    if (p.endsWith('_test.go')) {
+      return true
+    }
+    let files = fs.readdirSync(path.dirname(p))
+    for (let file of files) {
+      if (file.endsWith('_test.go')) {
+        return true
+      }
+    }
+    return false
+  }
+}
+export {Builder}

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import GoInformationView from './components/go-information-view'
 import {GoInformation} from './go-information'
 import {PanelManager} from './panel-manager'
 import {Formatter} from './formatter'
+import {Builder} from './builder'
 
 export default {
   dependenciesInstalled: null,
@@ -14,6 +15,7 @@ export default {
   subscriptions: null,
   toolRegistered: null,
   formatter: null,
+  builder: null,
 
   activate () {
     this.subscriptions = new CompositeDisposable()
@@ -46,11 +48,12 @@ export default {
     this.dependenciesInstalled = null
     this.toolRegistered = null
     this.formatter = null
+    this.builder = null
   },
 
   uninstallOldPackages () {
     // remove old packages that have been merged into go-plus
-    let pkgs = [ 'gofmt' ]
+    let pkgs = [ 'gofmt', 'builder-go' ]
     for (let pkg of pkgs) {
       let p = atom.packages.getLoadedPackage(pkg)
       if (!p) {
@@ -114,6 +117,21 @@ export default {
       () => { return this.getGoget() })
     this.subscriptions.add(this.formatter)
     return this.formatter
+  },
+
+  getBuilder () {
+    if (this.builder) {
+      return this.builder
+    }
+    this.builder = new Builder(
+      () => { return this.getGoconfig() }
+    )
+    this.subscriptions.add(this.builder)
+    return this.builder
+  },
+
+  provideLinter () {
+    return this.getBuilder()
   },
 
   consumeStatusBar (service) {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,12 @@
   "dependencies": {
     "atom-package-deps": "4.2.0",
     "etch": "0.6.3",
-    "etch-octicon": "^0.0.4"
+    "etch-octicon": "^0.0.4",
+    "temp": "^0.8.3",
+    "rimraf": "^2.5.4"
   },
   "devDependencies": {
-    "standard": "^8.3.0",
-    "temp": "^0.8.3"
+    "standard": "^8.3.0"
   },
   "package-deps": [
     "go-config",
@@ -49,7 +50,6 @@
     "navigator-go",
     "tester-go",
     "gorename",
-    "builder-go",
     "go-debug",
     "godoc"
   ],
@@ -72,6 +72,13 @@
     "go-get": {
       "versions": {
         "2.0.0": "consumeGoget"
+      }
+    }
+  },
+  "providedServices": {
+    "linter": {
+      "versions": {
+        "1.0.0": "provideLinter"
       }
     }
   },

--- a/spec/builder-spec.js
+++ b/spec/builder-spec.js
@@ -1,0 +1,59 @@
+'use babel'
+/* eslint-env jasmine */
+
+import path from 'path'
+
+describe('builder', () => {
+  let mainModule = null
+  let builder = null
+
+  beforeEach(() => {
+    waitsForPromise(() => {
+      return atom.packages.activatePackage('go-config').then(() => {
+        return atom.packages.activatePackage('language-go')
+      }).then(() => {
+        return atom.packages.activatePackage('go-plus')
+      }).then((pack) => {
+        mainModule = pack.mainModule
+      })
+    })
+
+    waitsFor(() => {
+      return mainModule.goconfig
+    })
+
+    waitsFor(() => {
+      builder = mainModule.getBuilder()
+      return builder
+    })
+  })
+
+  describe('getMessages', () => {
+    it('ignores duplicate errors', () => {
+      // GIVEN the same results from both 'go install' and 'go test'
+      let outputs = [
+        {
+          'output': '# github.com/anonymous/sample-project\n.\\the-file.go:12: syntax error: unexpected semicolon or newline, expecting comma or }',
+          'linterName': 'build'
+        },
+        {
+          'output': '# github.com/anonymous/sample-project\n.\\the-file.go:12: syntax error: unexpected semicolon or newline, expecting comma or }',
+          'linterName': 'test'
+        }
+      ]
+
+      // WHEN I get the messages for these outputs
+      let messages = builder.getMessages(outputs, path.join('src', 'github.com', 'anonymous', 'sample-project'))
+
+      // THEN I expect only one message to be returned because they are the same
+      expect(messages.length).toEqual(1)
+
+      let message = messages[0]
+      expect(message.name).toEqual('build')
+      expect(message.text.indexOf('syntax error: unexpected semicolon or newline, expecting comma or }') === 0).toBeTruthy()
+      expect(message.filePath.indexOf('the-file.go') > 0).toBeTruthy() // file is in the path
+      expect(message.filePath.indexOf('sample-project') > 0).toBeTruthy() // cwd is in the path
+      expect(message.row).toEqual('12')
+    })
+  })
+})


### PR DESCRIPTION
This will pave the way for better integration between go-plus features.  For example we'll be able to skip linting if the build fails.
- [x] add builder
- [x] add specs
- [x] uninstall builder-go package
- [x] update readme
- [ ] remove linter provider and integrate with go-plus panel
