### PR TITLE
Always show stderr output

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -319,17 +319,18 @@ class Tester {
         let executorOptions = this.getExecutorOptions(editor)
         this.testPanelManager().update({output: 'Running go ' + args.join(' '), state: 'pending', exitcode: 0})
         return config.executor.exec(cmd, args, executorOptions).then((r) => {
+          let output = r.stdout
+
           if (r.stderr && r.stderr.trim() !== '') {
-            let output = r.stderr + os.EOL + r.stdout
-            this.testPanelManager().update({exitcode: r.exitcode, output: output.trim(), state: 'fail'})
+            output = r.stderr + os.EOL + r.stdout
           }
 
           if (r.exitcode === 0) {
             this.ranges = parser.ranges(this.coverageFile)
             this.addMarkersToEditors()
-            this.testPanelManager().update({exitcode: r.exitcode, output: r.stdout, state: 'success'})
+            this.testPanelManager().update({exitcode: r.exitcode, output: output.trim(), state: 'success'})
           } else {
-            this.testPanelManager().update({exitcode: r.exitcode, output: r.stdout, state: 'fail'})
+            this.testPanelManager().update({exitcode: r.exitcode, output: output.trim(), state: 'fail'})
           }
 
           this.running = false


### PR DESCRIPTION
Currently stderr output is not always visible. I feel it is always useful to see it, especially when tests fail.

In any case, thank you for awesome plugin!