### PR TITLE
panelDisplayMode defaults to "closed"

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
       "title": "Panel Display Mode",
       "description": "Control the behavior of the go-plus panel when a new Atom window is opened",
       "type": "string",
-      "default": "open",
+      "default": "closed",
       "enum": [
         "open",
         "closed"


### PR DESCRIPTION
I use Atom mostly for JavaScript and CommonMark files.

Even though I find go-plus a pleasure to use when I'm writing Go code, I'd prefer it if the default state of the panel (for new Atom windows) was "closed".