### PR TITLE
Use activationHooks to speedup editor startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "bugs": {
     "url": "https://github.com/joefitzgerald/go-plus/issues"
   },
+  "activationHooks": [
+    "language-go:grammar-used",
+  ],
   "dependencies": {
     "ansi-to-html": "^0.4.2",
     "atom-package-deps": "4.2.0",


### PR DESCRIPTION
From the [docs](http://flight-manual.atom.io/hacking-atom/sections/package-word-count/):

> `activationHooks`: an Array of Strings identifying hooks that trigger your package's activation. The loading of your package is delayed until one of these hooks are triggered. Currently, the only activation hook is `language-package-name:grammar-used` (e.g., `language-javascript:grammar-used`)

This should speed up Atom startup time while no go files presented (since most of people use Atom as universal editor for many languages).

This should also hide go-plus panel while I'm working on python files for example. It should become visible after I open any go-file.

Not sure if specs will work correctly after this though.