### PR TITLE
adds the ability to show code coverage via the gutter

### DIFF
--- a/lib/tester.js
+++ b/lib/tester.js
@@ -177,8 +177,21 @@ class Tester {
           }
         }
       }
-      editor.decorateMarkerLayer(coveredLayer, {type: 'highlight', class: 'covered', onlyNonEmpty: true})
-      editor.decorateMarkerLayer(uncoveredLayer, {type: 'highlight', class: 'uncovered', onlyNonEmpty: true})
+
+      let type = atom.config.get("go-plus.test.coverageDisplayMode")
+      switch(type){
+        case "gutter":
+          type = "line-number"
+          break
+        case "highlight":
+          type = "highlight"
+          break
+        default:
+          type = "highlight"
+      }
+
+      editor.decorateMarkerLayer(coveredLayer, {type: type, class: 'covered', onlyNonEmpty: true})
+      editor.decorateMarkerLayer(uncoveredLayer, {type: type, class: 'uncovered', onlyNonEmpty: true})
     } catch (e) {
       console.log(e)
     }

--- a/package.json
+++ b/package.json
@@ -168,12 +168,23 @@
           ],
           "order": 3
         },
+        "coverageDisplayMode": {
+          "title": "Coverage Display Mode",
+          "description": "Control the way that coverage is displayed in the editor: gutter, or highlight",
+          "type": "string",
+          "default": "highlight",
+          "enum":[
+            "highlight",
+            "gutter"
+          ],
+          "order": 4
+        },
         "focusPanelIfTestsFail": {
           "title": "Focus The go-plus Panel If Tests Fail",
           "description": "If the panel is hidden, or the panel is showing a different tab, the panel will be expanded and the test tab focused when tests fail.",
           "type": "boolean",
           "default": true,
-          "order": 4
+          "order": 5
         }
       }
     }

--- a/styles/go-plus-test.atom-text-editor.less
+++ b/styles/go-plus-test.atom-text-editor.less
@@ -9,3 +9,11 @@
   background-color: @background-color-success;
   opacity: 0.2;
 }
+
+.line-number.uncovered{
+  background-color: @background-color-error;
+}
+
+.line-number.covered{
+  background-color: @background-color-success;
+}


### PR DESCRIPTION
Moved the changes from the other repo to here. I've made some of the changes that you asked for too. I'm not sure how to apply both decorators though (new to atom), sorry. 

