### PR TITLE
Add support for the default GOPATH in go 1.8+

### DIFF
--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -1,6 +1,7 @@
 'use babel'
 
 import pathhelper from './pathhelper'
+import path from 'path'
 
 const getenvironment = () => {
   const e = Object.assign({}, process.env)
@@ -24,7 +25,8 @@ const getgopath = () => {
     return pathhelper.expand(process.env, g)
   }
 
-  return false
+  // Default gopath in go 1.8+
+  return path.join(pathhelper.home(), 'go')
 }
 
 export {getenvironment, getgopath}

--- a/spec/config/environment-spec.js
+++ b/spec/config/environment-spec.js
@@ -5,10 +5,14 @@ import {getgopath} from './../../lib/config/environment'
 import pathhelper from './../../lib/config/pathhelper'
 import path from 'path'
 import {lifecycle} from './../spec-helpers'
+import temp from 'temp'
 
 describe('executor', () => {
+  let [envDir, configDir] = []
   beforeEach(() => {
     lifecycle.setup()
+    envDir = temp.path('gopathenv')
+    configDir = temp.path('gopathconfig')
   })
 
   afterEach(() => {
@@ -17,13 +21,13 @@ describe('executor', () => {
 
   describe('there is a gopath in the environment', () => {
     beforeEach(() => {
-      process.env.GOPATH = '/xyz'
-      atom.config.set('go-plus.config.gopath', '/abc')
+      process.env.GOPATH = envDir
+      atom.config.set('go-plus.config.gopath', configDir)
     })
 
-    it('uses the config\'s gopath', () => {
+    it('uses the environment\'s gopath', () => {
       expect(getgopath()).toBeTruthy()
-      expect(getgopath()).toBe('/xyz')
+      expect(getgopath()).toBe(envDir)
     })
   })
 
@@ -42,12 +46,12 @@ describe('executor', () => {
   describe('there is a gopath in config and not in the environment', () => {
     beforeEach(() => {
       delete process.env.GOPATH
-      atom.config.set('go-plus.config.gopath', '/abc')
+      atom.config.set('go-plus.config.gopath', configDir)
     })
 
     it('uses the config\'s gopath', () => {
       expect(getgopath()).toBeTruthy()
-      expect(getgopath()).toBe('/abc')
+      expect(getgopath()).toBe(configDir)
     })
   })
 })

--- a/spec/config/environment-spec.js
+++ b/spec/config/environment-spec.js
@@ -1,0 +1,53 @@
+'use babel'
+/* eslint-env jasmine */
+
+import {getgopath} from './../../lib/config/environment'
+import pathhelper from './../../lib/config/pathhelper'
+import path from 'path'
+import {lifecycle} from './../spec-helpers'
+
+describe('executor', () => {
+  beforeEach(() => {
+    lifecycle.setup()
+  })
+
+  afterEach(() => {
+    lifecycle.teardown()
+  })
+
+  describe('there is a gopath in the environment', () => {
+    beforeEach(() => {
+      process.env.GOPATH = '/xyz'
+      atom.config.set('go-plus.config.gopath', '/abc')
+    })
+
+    it('uses the config\'s gopath', () => {
+      expect(getgopath()).toBeTruthy()
+      expect(getgopath()).toBe('/xyz')
+    })
+  })
+
+  describe('there is no gopath in the environment or config', () => {
+    beforeEach(() => {
+      delete process.env.GOPATH
+      atom.config.set('go-plus.config.gopath', '')
+    })
+
+    it('uses the default gopath', () => {
+      expect(getgopath()).toBeTruthy()
+      expect(getgopath()).toBe(path.join(pathhelper.home(), 'go'))
+    })
+  })
+
+  describe('there is a gopath in config and not in the environment', () => {
+    beforeEach(() => {
+      delete process.env.GOPATH
+      atom.config.set('go-plus.config.gopath', '/abc')
+    })
+
+    it('uses the config\'s gopath', () => {
+      expect(getgopath()).toBeTruthy()
+      expect(getgopath()).toBe('/abc')
+    })
+  })
+})

--- a/spec/config/locator-spec.js
+++ b/spec/config/locator-spec.js
@@ -136,9 +136,9 @@ describe('Locator', () => {
       }
     })
 
-    it('gopath() returns false', () => {
+    it('gopath() returns the default GOPATH', () => {
       expect(locator.gopath).toBeDefined()
-      expect(locator.gopath()).toBe(false)
+      expect(locator.gopath()).toBe(path.join(os.homedir(), 'go'))
     })
 
     describe('when there is atom config for go-plus.config.gopath', () => {
@@ -169,9 +169,9 @@ describe('Locator', () => {
       process.env.GOPATH = '        '
     })
 
-    it('gopath() returns false', () => {
+    it('gopath() returns the default GOPATH', () => {
       expect(locator.gopath).toBeDefined()
-      expect(locator.gopath()).toBe(false)
+      expect(locator.gopath()).toBe(path.join(os.homedir(), 'go'))
     })
 
     describe('when there is atom config for go-plus.config.gopath', () => {


### PR DESCRIPTION
- Make use of it for any go version

Fixes #547 