### PR TITLE
Improve navigation with guru

### DIFF
--- a/lib/navigator/godef.js
+++ b/lib/navigator/godef.js
@@ -137,31 +137,35 @@ class Godef {
         options.input = archive
       }
 
-      const goto = (pos) => {
-        const offset = this.utf8OffsetForBufferPosition(pos, editor)
-        const args = ['-json', 'definition', filepath + ':#' + offset]
-        if (archive && archive !== '') {
-          args.unshift('-modified')
-        }
-
-        return this.goconfig.executor.exec(cmd, args, options)
+      pos = this.checkGuruPosition(pos, editor)
+      const offset = this.utf8OffsetForBufferPosition(pos, editor)
+      const args = ['-json', 'definition', filepath + ':#' + offset]
+      if (archive && archive !== '') {
+        args.unshift('-modified')
       }
 
-      return goto(pos).then((r) => {
-        if (r.exitcode !== 0) {
-          // unfortunately guru fails if the cursor is at the end of a word
-          // e.g. "fmt.Println ()"
-          //                  ↑ the cursor is here, between "ln" and "("
-          // So go back by 1 column and ask guru again, maybe it works now
-          if (pos.column !== 0) {
-            const prevPos = pos.copy()
-            prevPos.column--
-            return goto(prevPos)
-          }
-        }
-        return r
-      })
+      return this.goconfig.executor.exec(cmd, args, options)
     })
+  }
+
+  checkGuruPosition (pos, editor) {
+    // Unfortunately guru fails if the cursor is at the end of a word
+    // e.g. "fmt.Println ()"
+    //                  ↑ the cursor is here, between "ln" and "("
+    // In order to avoid this problem we have to check whether the char
+    // at the given position is considered a part of an identifier.
+    // If not step back 1 char as it might contain a valid identifier.
+    const char = editor.getTextInBufferRange([
+      pos,
+      pos.translate([0, 1])
+    ])
+    const nonWordChars = editor.getNonWordCharacters(
+      editor.scopeDescriptorForBufferPosition(pos)
+    )
+    if (nonWordChars.indexOf(char) >= 0 || /\s/.test(char)) {
+      return pos.translate([0, -1])
+    }
+    return pos
   }
 
   gotoDefinitionGodef (pos, editor) {

--- a/lib/navigator/godef.js
+++ b/lib/navigator/godef.js
@@ -75,72 +75,108 @@ class Godef {
 
   gotoDefinitionForBufferPosition (pos, editor = getEditor()) {
     if (!editor || !pos) {
+      return false
+    }
+    const tool = atom.config.get('go-plus.navigator.mode')
+    let prom
+    if (tool === 'guru') {
+      prom = this.gotoDefinitionGuru(pos, editor)
+    } else {
+      prom = this.gotoDefinitionGodef(pos, editor)
+    }
+    return prom.then((r) => {
+      if (!r) {
+        return r
+      }
+
+      if (r.stderr && r.stderr.trim() !== '') {
+        console.log(tool + ': (stderr) ' + r.stderr)
+      }
+
+      if (r.exitcode !== 0) {
+        atom.notifications.addError('go-plus', {
+          dismissable: false,
+          icon: 'location',
+          detail: r.stderr.trim()
+        })
+        return false
+      }
+
+      if (tool === 'guru') {
+        return this.visitLocation(this.parseGuruLocation(r.stdout))
+      }
+      return this.visitLocation(this.parseGodefLocation(r.stdout))
+    }).catch((e) => {
+      console.log(e)
+      return false
+    })
+  }
+
+  gotoDefinitionGuru (pos, editor) {
+    if (!editor || !pos) {
       return
     }
-    const offset = this.utf8OffsetForBufferPosition(pos, editor)
-    const tool = atom.config.get('go-plus.navigator.mode')
-    return this.goconfig.locator.findTool(tool).then((cmd) => {
+
+    return this.goconfig.locator.findTool('guru').then((cmd) => {
       if (!cmd) {
-        return
+        return false
       }
 
       const filepath = editor.getPath()
-      let args
       let archive = ''
-      if (tool === 'guru') {
-        for (const e of atom.workspace.getTextEditors()) {
-          if (e.isModified() && isValidEditor(e)) {
-            archive += e.getTitle() + '\n'
-            archive += Buffer.byteLength(e.getText(), 'utf8') + '\n'
-            archive += e.getText()
-          }
+      for (const e of atom.workspace.getTextEditors()) {
+        if (e.isModified() && isValidEditor(e)) {
+          archive += e.getTitle() + '\n'
+          archive += Buffer.byteLength(e.getText(), 'utf8') + '\n'
+          archive += e.getText()
         }
-        args = ['-json', 'definition', filepath + ':#' + offset]
-        if (archive && archive !== '') {
-          args.unshift('-modified')
-        }
-      } else {
-        args = ['-f', filepath, '-o', offset, '-i']
       }
+
       const options = this.goconfig.executor.getOptions('file')
-      if (tool === 'godef') {
-        options.input = editor.getText()
-      } else if (tool === 'guru' && archive && archive !== '') {
+      if (archive && archive !== '') {
         options.input = archive
       }
 
-      return this.goconfig.executor.exec(cmd, args, options).then((r) => {
-        if (r.stderr && r.stderr.trim() !== '') {
-          console.log(tool + ': (stderr) ' + r.stderr)
+      const goto = (pos) => {
+        const offset = this.utf8OffsetForBufferPosition(pos, editor)
+        const args = ['-json', 'definition', filepath + ':#' + offset]
+        if (archive && archive !== '') {
+          args.unshift('-modified')
         }
 
+        return this.goconfig.executor.exec(cmd, args, options)
+      }
+
+      return goto(pos).then((r) => {
         if (r.exitcode !== 0) {
-          atom.notifications.addError('go-plus', {
-            dismissable: false,
-            icon: 'location',
-            detail: r.stderr.trim()
-          })
-          return false
+          // unfortunately guru fails if the cursor is at the end of a word
+          // e.g. "fmt.Println ()"
+          //                  ↑ the cursor is here, between "ln" and "("
+          // So go back by 1 column and ask guru again, maybe it works now
+          if (pos.column !== 0) {
+            const prevPos = pos.copy()
+            prevPos.column--
+            return goto(prevPos)
+          }
         }
-
-        if (tool === 'guru') {
-          return this.visitLocation(this.parseGuruLocation(r.stdout))
-        }
-        return this.visitLocation(this.parseGodefLocation(r.stdout))
-      }).catch((e) => {
-        console.log(e)
-        return false
+        return r
       })
     })
   }
 
-  checkForTool (editor = getEditor()) {
+  gotoDefinitionGodef (pos, editor) {
     return this.goconfig.locator.findTool('godef').then((cmd) => {
-      if (cmd) {
-        return cmd
+      if (!cmd) {
+        return
       }
 
-      return false
+      const offset = this.utf8OffsetForBufferPosition(pos, editor)
+      const filepath = editor.getPath()
+      const args = ['-f', filepath, '-o', offset, '-i']
+      const options = this.goconfig.executor.getOptions('file')
+      options.input = editor.getText()
+
+      return this.goconfig.executor.exec(cmd, args, options)
     })
   }
 
@@ -321,9 +357,11 @@ class Godef {
     const marker = editor.markBufferRange(range, {invalidate: 'inside'})
     editor.decorateMarker(marker, {type: 'highlight', class: 'definition'})
     const cursor = editor.getLastCursor()
-    cursor.onDidChangePosition(() => {
+    const onDidChange = () => {
       marker.destroy()
-    })
+      cursor.emitter.off('did-change-position', onDidChange)
+    }
+    cursor.onDidChangePosition(onDidChange)
   }
 }
 

--- a/spec/navigator/godef-spec.js
+++ b/spec/navigator/godef-spec.js
@@ -88,12 +88,33 @@ describe('go to definition', () => {
 
     describe('when using the guru navigator mode', () => {
       beforeEach(() => {
-        atom.config.set('go-plus.navigator.mode', 'godef')
+        atom.config.set('go-plus.navigator.mode', 'guru')
       })
 
       it('navigates to the correct location', () => {
         runs(() => {
-          editor.setCursorBufferPosition([3, 17])
+          editor.setCursorBufferPosition([3, 17]) // at the beginning of -> `Bar()`
+        })
+
+        waitsForPromise(() => {
+          return godef.gotoDefinitionForWordAtCursor()
+        })
+
+        runs(() => {
+          const activeEditor = atom.workspace.getActiveTextEditor()
+          expect(activeEditor.getTitle()).toBe('bar.go')
+
+          const pos = activeEditor.getCursorBufferPosition()
+          expect(pos.row).toBe(2)
+          expect(pos.column).toBe(5)
+
+          expect(godef.navigationStack.isEmpty()).toBe(false)
+        })
+      })
+
+      it('navigates to the correct location if at the end of a word', () => {
+        runs(() => {
+          editor.setCursorBufferPosition([3, 20]) // at the end of `Bar()` <-
         })
 
         waitsForPromise(() => {


### PR DESCRIPTION
It currently fails if the cursor is at the end of a word:
```go
fmt.Println ("hello world")
//         ↑ if cursor is here between `ln` and `(` it fails
```

Solution: call guru with `position.column - 1` (simply step back 1 character)