### PR TITLE
Add config option for additional go test args

### DIFF
--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -228,10 +228,10 @@ class Tester {
 
     let shortFlag = false
     let verboseFlag = false
+    let userSuppliedTimout = false
 
     if (configFlags && configFlags.length) {
       const arr = configFlags.trim().split(/\s+/g)
-      let userSuppliedTimout = false
 
       for (const arg of arr) {
         args.push(arg)
@@ -245,9 +245,10 @@ class Tester {
           verboseFlag = true
         }
       }
-      if (!userSuppliedTimout) {
-        args.push('-timeout=' + timeoutMillis + 'ms')
-      }
+    }
+
+    if (!userSuppliedTimout) {
+      args.push('-timeout=' + timeoutMillis + 'ms')
     }
 
     if (!shortFlag && atom.config.get('go-plus.test.runTestsWithShortFlag')) {

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -4,6 +4,7 @@ import {CompositeDisposable} from 'atom'
 import _ from 'lodash'
 import fs from 'fs'
 import os from 'os'
+import argparser from 'yargs-parser/lib/tokenize-arg-string'
 import parser from './gocover-parser'
 import path from 'path'
 import rimraf from 'rimraf'
@@ -231,7 +232,7 @@ class Tester {
     let userSuppliedTimout = false
 
     if (configFlags && configFlags.length) {
-      const arr = configFlags.trim().split(/\s+/g)
+      const arr = argparser(configFlags)
 
       for (const arg of arr) {
         args.push(arg)

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -222,6 +222,44 @@ class Tester {
     this.coverageFile = path.join(this.tempDir, 'coverage.out')
   }
 
+  buildGoTestArgs (timeoutMillis = 60000) {
+    const args = ['test', '-coverprofile=' + this.coverageFile]
+    const configFlags = atom.config.get('go-plus.test.additionalTestFlags')
+
+    let shortFlag = false
+    let verboseFlag = false
+
+    if (configFlags && configFlags.length) {
+      const arr = configFlags.trim().split(/\s+/g)
+      let userSuppliedTimout = false
+
+      for (const arg of arr) {
+        args.push(arg)
+        if (arg.startsWith('-timeout')) {
+          userSuppliedTimout = true
+        }
+        if (arg === '-short') {
+          shortFlag = true
+        }
+        if (arg === '-v') {
+          verboseFlag = true
+        }
+      }
+      if (!userSuppliedTimout) {
+        args.push('-timeout=' + timeoutMillis + 'ms')
+      }
+    }
+
+    if (!shortFlag && atom.config.get('go-plus.test.runTestsWithShortFlag')) {
+      args.push('-short')
+    }
+    if (!verboseFlag && atom.config.get('go-plus.test.runTestsWithVerboseFlag')) {
+      args.push('-v')
+    }
+
+    return args
+  }
+
   runTests (editor = getEditor()) {
     if (!isValidEditor(editor)) {
       return Promise.resolve()
@@ -268,15 +306,10 @@ class Tester {
           executorOptions.timeout = 60000
         }
         const cmd = go
-        const args = ['test', '-timeout=' + executorOptions.timeout + 'ms', '-coverprofile=' + this.coverageFile]
-        if (atom.config.get('go-plus.test.runTestsWithShortFlag')) {
-          args.push('-short')
-        }
-        if (atom.config.get('go-plus.test.runTestsWithVerboseFlag')) {
-          args.push('-v')
-        }
+        const args = this.buildGoTestArgs(executorOptions.timeout)
+
         if (this.testPanelManager) {
-          this.testPanelManager.update({output: 'Running go ' + args.join(' ') + ' with a ' + atom.config.get('go-plus.test.timeout') + 'ms timeout', state: 'pending', exitcode: 0})
+          this.testPanelManager.update({output: 'Running go ' + args.join(' '), state: 'pending', exitcode: 0})
         }
 
         return this.goconfig.executor.exec(cmd, args, executorOptions).then((r) => {

--- a/package.json
+++ b/package.json
@@ -393,6 +393,13 @@
           "default": false,
           "order": 4
         },
+        "additionalTestFlags": {
+          "title": "Additional Test Flags",
+          "description": "Flags to pass to `go test`",
+          "type": "string",
+          "default": "",
+          "order": 5
+        },
         "coverageHighlightMode": {
           "title": "Coverage Highlight Mode",
           "description": "Control the way that coverage highlighting occurs",
@@ -404,7 +411,7 @@
             "uncovered",
             "disabled"
           ],
-          "order": 5
+          "order": 6
         },
         "coverageDisplayMode": {
           "title": "Coverage Display Mode",
@@ -415,14 +422,14 @@
             "highlight",
             "gutter"
           ],
-          "order": 6
+          "order": 7
         },
         "focusPanelIfTestsFail": {
           "title": "Focus The go-plus Panel If Tests Fail",
           "description": "If the panel is hidden, or the panel is showing a different tab, the panel will be expanded and the test tab focused when tests fail.",
           "type": "boolean",
           "default": true,
-          "order": 7
+          "order": 8
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "lodash": "^4.17.4",
     "rimraf": "^2.5.4",
     "semver": "^5.3.0",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "yargs-parser": "^4.2.1"
   },
   "devDependencies": {
     "fs-extra": "^1.0.0",

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -47,6 +47,10 @@ describe('tester', () => {
   })
 
   describe('go test args', () => {
+    beforeEach(() => {
+      atom.config.unset('go-plus.test.additionalTestFlags')
+    })
+
     afterEach(() => {
       atom.config.set('go-plus.test.runTestsWithShortFlag', true)
       atom.config.set('go-plus.test.runTestsWithVerboseFlag', false)
@@ -54,11 +58,14 @@ describe('tester', () => {
 
     it('uses the specified timeout', () => {
       const args = tester.buildGoTestArgs(10000)
+      let foundTimeout = false
       for (const arg of args) {
         if (arg.startsWith('-timeout')) {
+          foundTimeout = true
           expect(arg).toBe('-timeout=10000ms')
         }
       }
+      expect(foundTimeout).toBe(true)
     })
 
     it('invokes the go test command with a coverprofile', () => {
@@ -71,11 +78,14 @@ describe('tester', () => {
       it('prefers timeout from the custom args (if specified)', () => {
         atom.config.set('go-plus.test.additionalTestFlags', '-timeout=4000ms')
         const args = tester.buildGoTestArgs(8000)
+        let foundTimeout = false
         for (const arg of args) {
           if (arg.startsWith('-timeout')) {
+            foundTimeout = true
             expect(arg).toBe('-timeout=4000ms')
           }
         }
+        expect(foundTimeout).toBe(true)
       })
 
       it('does not duplicate the -short or -verbose flags', () => {

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -46,6 +46,53 @@ describe('tester', () => {
     lifecycle.teardown()
   })
 
+  describe('go test args', () => {
+    afterEach(() => {
+      atom.config.set('go-plus.test.runTestsWithShortFlag', true)
+      atom.config.set('go-plus.test.runTestsWithVerboseFlag', false)
+    })
+
+    it('uses the specified timeout', () => {
+      const args = tester.buildGoTestArgs(10000)
+      for (const arg of args) {
+        if (arg.startsWith('-timeout')) {
+          expect(arg).toBe('-timeout=10000ms')
+        }
+      }
+    })
+
+    it('invokes the go test command with a coverprofile', () => {
+      const args = tester.buildGoTestArgs(10000)
+      expect(args[0]).toBe('test')
+      expect(args[1].startsWith('-coverprofile=')).toBe(true)
+    })
+
+    describe('when specifying custom args', () => {
+      it('prefers timeout from the custom args (if specified)', () => {
+        atom.config.set('go-plus.test.additionalTestFlags', '-timeout=4000ms')
+        const args = tester.buildGoTestArgs(8000)
+        for (const arg of args) {
+          if (arg.startsWith('-timeout')) {
+            expect(arg).toBe('-timeout=4000ms')
+          }
+        }
+      })
+
+      it('does not duplicate the -short or -verbose flags', () => {
+        atom.config.set('go-plus.test.runTestsWithShortFlag', true)
+        atom.config.set('go-plus.test.runTestsWithVerboseFlag', true)
+        atom.config.set('go-plus.test.additionalTestFlags', '-short -verbose')
+
+        const args = tester.buildGoTestArgs()
+        const shortFlags = args.filter((a) => a === '-short').length
+        const verboseFlags = args.filter((a) => a === '-v').length
+
+        expect(shortFlags).toBe(1)
+        expect(verboseFlags).toBe(1)
+      })
+    })
+  })
+
   describe('when run coverage on save is disabled', () => {
     let filePath
     let testFilePath

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -100,6 +100,13 @@ describe('tester', () => {
         expect(shortFlags).toBe(1)
         expect(verboseFlags).toBe(1)
       })
+
+      it('handles args with spaces', () => {
+        atom.config.set('go-plus.test.additionalTestFlags', '-myarg="hello world"')
+        const args = tester.buildGoTestArgs()
+        expect(args.length >= 3).toBeTruthy()
+        expect(args[2]).toBe('-myarg=hello world')
+      })
     })
   })
 


### PR DESCRIPTION
Add a new configuration option `go-plus.test.additionalTestFlags` to allow the user to specify additional flags to the `go test` command.

Test flags here take precedence so:
- if this option includes a `-timeout` flag it will override `go-plus.test.timeout`
- if this option includes `-short` or `-v` flags they will be used no matter what the value of the `runTestsWithShortFlag` or  `runTestsWithVerboseFlag` options are (note that these options can still _append_ to the overall set of args)

Fixes #551, See also #308.

The jury's out on whether this actually a good idea or not.  I'm doing minimal validation on what the user specifies, so it's possible for the user to shoot themselves in the foot and specify something that breaks `go test` or overrides our coverprofile settings.

**Note:** it seems our tests are broken on Atom 1.15 beta, which is unrelated to this PR.
