### PR TITLE
New feature: modify struct tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - go get -u github.com/alecthomas/gometalinter
   - go get -u github.com/zmb3/gogetdoc
   - go get -u github.com/rogpeppe/godef
+  - go get -u github.com/fatih/gomodifytags
   - go get -u golang.org/x/tools/cmd/guru
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ install:
   - go get -u github.com/alecthomas/gometalinter
   - go get -u github.com/zmb3/gogetdoc
   - go get -u github.com/rogpeppe/godef
+  - go get -u github.com/fatih/gomodifytags
   - go get -u golang.org/x/tools/cmd/guru
 
 build_script:

--- a/keymaps/go-plus.json
+++ b/keymaps/go-plus.json
@@ -10,6 +10,8 @@
     "ctrl-alt-shift-g r": "golang:goreturns",
     "ctrl-alt-shift-g t": "golang:run-tests",
     "ctrl-alt-shift-g x": "golang:hide-coverage",
+    "ctrl-alt-shift-g t": "golang:add-tags",
+    "ctrl-alt-shift-g u": "golang:remove-tags",
     "alt-d": "golang:showdoc",
     "alt-r": "golang:gorename"
   },
@@ -20,5 +22,9 @@
   ":not(.platform-darwin) atom-text-editor[data-grammar~=\"go\"]:not([mini])": {
     "alt-ctrl-g": "golang:godef",
     "alt-ctrl-shift-g": "golang:godef-return"
+  },
+  ".gomodifytags": {
+    "tab": "gomodifytags:focus-next",
+    "shift-tab": "gomodifytags:focus-previous"
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,7 @@ export default {
   getservice: null,
   godoc: null,
   gorename: null,
+  gomodifytags: null,
   loaded: null,
   panelManager: null,
   statusbar: null,
@@ -55,6 +56,7 @@ export default {
     this.autocompleteProvider = null
     this.godoc = null
     this.gorename = null
+    this.gomodifytags = null
     this.godef = null
     this.hyperclickProvider = null
   },
@@ -66,6 +68,7 @@ export default {
     this.loadTester()
     this.loadDoc()
     this.loadGorename()
+    this.loadGoModifyTags()
     this.getGodef()
     if (!atom.config.get('go-plus.testing')) {
       this.loadPackageManager()
@@ -194,6 +197,18 @@ export default {
     }
 
     return this.gorename
+  },
+
+  loadGoModifyTags () {
+    if (this.gomodifytags) {
+      return this.gomodifytags
+    }
+    const GoModifyTags = require('./tags/gomodifytags')
+    this.gomodifytags = new GoModifyTags(this.provideGoConfig())
+    if (this.subscriptions) {
+      this.subscriptions.add(this.gomodifytags)
+    }
+    return this.gomodifytags
   },
 
   getBuilder () {

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -32,7 +32,8 @@ const goTools = new Map([
   ['gometalinter', 'github.com/alecthomas/gometalinter'],
   ['gogetdoc', 'github.com/zmb3/gogetdoc'],
   ['godef', 'github.com/rogpeppe/godef'],
-  ['guru', 'golang.org/x/tools/cmd/guru']
+  ['guru', 'golang.org/x/tools/cmd/guru'],
+  ['gomodifytags', 'github.com/fatih/gomodifytags']
 ])
 
 class PackageManager {

--- a/lib/tags/gomodifytags.js
+++ b/lib/tags/gomodifytags.js
@@ -1,0 +1,175 @@
+'use babel'
+
+import {CompositeDisposable, Point} from 'atom'
+import {isValidEditor} from '../utils'
+import TagsDialog from './tags-dialog'
+
+export default class GoModifyTags {
+  constructor (goconfig) {
+    this.goconfig = goconfig
+    this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(atom.commands.add(
+      'atom-workspace', 'golang:add-tags',
+      () => this.commandInvoked('Add')
+    ))
+    this.subscriptions.add(atom.commands.add(
+      'atom-workspace', 'golang:remove-tags',
+      () => this.commandInvoked('Remove')
+    ))
+  }
+
+  dispose () {
+    this.subscriptions.dispose()
+    this.subscriptions = null
+    this.goconfig = null
+  }
+
+  commandInvoked (mode) {
+    const editor = atom.workspace.getActiveTextEditor()
+    if (!isValidEditor(editor)) {
+      return
+    }
+
+    if (editor.hasMultipleCursors()) {
+      atom.notifications.addWarning('go-plus', {
+        dismissable: true,
+        icon: 'tag',
+        detail: 'Modifying tags only works with a single cursor'
+      })
+      return
+    }
+
+    return this.goconfig.locator.findTool('gomodifytags').then((cmd) => {
+      const dialog = new TagsDialog({
+        mode: mode
+      })
+      dialog.onAccept = (options) => this.modifyTags(editor, options, mode, cmd)
+      dialog.attach()
+    })
+  }
+
+  modifyTags (editor, options, mode, cmd) {
+    const {tags, useSnakeCase, sortTags} = options
+    const executorOptions = this.goconfig.executor.getOptions('file')
+
+    // if there is a selection, use the -line flag,
+    // otherwise just use the cursor offset (and apply modifications to entire struct)
+    const args = ['-file', editor.getTitle()]
+    const selection = editor.getSelectedBufferRange()
+    if (selection && !selection.start.isEqual(selection.end)) {
+      args.push('-line')
+      if (selection.isSingleLine()) {
+        args.push(`${selection.start.row + 1}`)
+      } else {
+        args.push(`${selection.start.row + 1},${selection.end.row + 1}`)
+      }
+    } else {
+      args.push('-offset')
+      args.push(this.editorByteOffset(editor))
+    }
+
+    if (editor.isModified()) {
+      let archive = ''
+      archive += editor.getTitle() + '\n'
+      archive += Buffer.byteLength(editor.getText(), 'utf8') + '\n'
+      archive += editor.getText()
+
+      args.push('-modified')
+      executorOptions.input = archive
+    }
+
+    args.push('-w')
+    // args.push('-format')
+    // args.push('json')
+
+    if (!useSnakeCase) {
+      args.push('-transform')
+      args.push('camelcase')
+    }
+    if (sortTags) {
+      args.push('-sort')
+    }
+
+    if (mode === 'Add') {
+      const tagNames = []
+      const opts = []
+      for (const t of tags) {
+        tagNames.push(t.tag)
+        if (t.option && t.option.length) {
+          opts.push(`${t.tag}=${t.option}`)
+        }
+      }
+      if (opts.length > 0) {
+        args.push('-add-options')
+        args.push(opts.join(','))
+      } else {
+        if (tagNames.length === 0) {
+          tagNames.push('json')
+        }
+        args.push('-add-tags', tagNames.join(','))
+      }
+    } else if (mode === 'Remove') {
+      const tagNames = []
+      const opts = []
+      if (!tags || !tags.length) {
+        args.push('-clear-tags')
+      } else {
+        for (const t of tags) {
+          tagNames.push(t.tag)
+          if (t.option && t.option.length) {
+            opts.push(`${t.tag}=${t.option}`)
+          }
+        }
+        if (tagNames.length > 0) {
+          args.push('-remove-tags')
+          args.push(tagNames.join(','))
+        }
+        if (opts.length > 0) {
+          args.push('remove-options')
+          args.push(opts.join(','))
+        }
+      }
+    }
+    if (atom.inDevMode()) {
+      console.log('(go-plus): executing: gomodifytags ' + args.join(' '))
+    }
+    return this.goconfig.executor.exec(cmd, args, executorOptions).then((r) => {
+      if (r.error) {
+        if (r.error && r.error.code === 'ENOENT') {
+          atom.notifications.addError('Missing Tool', {
+            detail: 'Missing the `gomodifytags` tool.',
+            dismissable: true
+          })
+        } else {
+          atom.notifications.addError('Error', {
+            detail: r.error.message,
+            dismissable: true
+          })
+        }
+        return {success: false, result: r}
+      } else if (r.exitcode !== 0) {
+        atom.notifications.addError('Error', {
+          detail: r.stderr.trim(),
+          dismissable: true
+        })
+      }
+      // const result = JSON.parse(r.stdout.trim())
+      // if (result) {
+      //   editor.transact(() => {
+      //
+      //   })
+      //   return {success: true, result: r}
+      // }
+      return {success: true, result: r}
+    })
+  }
+
+  editorByteOffset (editor) {
+    const cursor = editor.getLastCursor()
+    const range = cursor.getCurrentWordBufferRange()
+    const middle = new Point(range.start.row, Math.floor((range.start.column + range.end.column) / 2))
+    const charOffset = editor.buffer.characterIndexForPosition(middle)
+    const text = editor.getText().substring(0, charOffset)
+    return Buffer.byteLength(text, 'utf8')
+  }
+}

--- a/lib/tags/gomodifytags.js
+++ b/lib/tags/gomodifytags.js
@@ -48,9 +48,8 @@ export default class GoModifyTags {
     })
   }
 
-  modifyTags (editor, options, mode, cmd) {
+  buildArgs (editor, options, mode) {
     const {tags, useSnakeCase, sortTags} = options
-    const executorOptions = this.goconfig.executor.getOptions('file')
 
     // if there is a selection, use the -line flag,
     // otherwise just use the cursor offset (and apply modifications to entire struct)
@@ -69,13 +68,7 @@ export default class GoModifyTags {
     }
 
     if (editor.isModified()) {
-      let archive = ''
-      archive += editor.getTitle() + '\n'
-      archive += Buffer.byteLength(editor.getText(), 'utf8') + '\n'
-      archive += editor.getText()
-
       args.push('-modified')
-      executorOptions.input = archive
     }
 
     args.push('-w')
@@ -114,9 +107,10 @@ export default class GoModifyTags {
         args.push('-clear-tags')
       } else {
         for (const t of tags) {
-          tagNames.push(t.tag)
           if (t.option && t.option.length) {
             opts.push(`${t.tag}=${t.option}`)
+          } else {
+            tagNames.push(t.tag)
           }
         }
         if (tagNames.length > 0) {
@@ -124,11 +118,28 @@ export default class GoModifyTags {
           args.push(tagNames.join(','))
         }
         if (opts.length > 0) {
-          args.push('remove-options')
+          args.push('-remove-options')
           args.push(opts.join(','))
         }
       }
     }
+    return args
+  }
+
+  modifyTags (editor, options, mode, cmd) {
+    const executorOptions = this.goconfig.executor.getOptions('file')
+
+    if (editor.isModified()) {
+      let archive = ''
+      archive += editor.getTitle() + '\n'
+      archive += Buffer.byteLength(editor.getText(), 'utf8') + '\n'
+      archive += editor.getText()
+
+      executorOptions.input = archive
+    }
+
+    const args = this.buildArgs(editor, options, mode)
+
     if (atom.inDevMode()) {
       console.log('(go-plus): executing: gomodifytags ' + args.join(' '))
     }

--- a/lib/tags/gomodifytags.js
+++ b/lib/tags/gomodifytags.js
@@ -71,10 +71,6 @@ export default class GoModifyTags {
       args.push('-modified')
     }
 
-    args.push('-w')
-    // args.push('-format')
-    // args.push('json')
-
     if (!useSnakeCase) {
       args.push('-transform')
       args.push('camelcase')
@@ -162,14 +158,9 @@ export default class GoModifyTags {
           detail: r.stderr.trim(),
           dismissable: true
         })
+        return {success: false, result: r}
       }
-      // const result = JSON.parse(r.stdout.trim())
-      // if (result) {
-      //   editor.transact(() => {
-      //
-      //   })
-      //   return {success: true, result: r}
-      // }
+      editor.getBuffer().setTextViaDiff(r.stdout)
       return {success: true, result: r}
     })
   }

--- a/lib/tags/gomodifytags.js
+++ b/lib/tags/gomodifytags.js
@@ -102,12 +102,11 @@ export default class GoModifyTags {
       if (opts.length > 0) {
         args.push('-add-options')
         args.push(opts.join(','))
-      } else {
-        if (tagNames.length === 0) {
-          tagNames.push('json')
-        }
-        args.push('-add-tags', tagNames.join(','))
       }
+      if (tagNames.length === 0) {
+        tagNames.push('json')
+      }
+      args.push('-add-tags', tagNames.join(','))
     } else if (mode === 'Remove') {
       const tagNames = []
       const opts = []

--- a/lib/tags/tags-dialog.js
+++ b/lib/tags/tags-dialog.js
@@ -1,0 +1,155 @@
+/** @babel */
+/** @jsx etch.dom */
+/* eslint-disable react/no-unknown-property */
+
+import {CompositeDisposable, TextEditor} from 'atom'
+import etch from 'etch'
+import EtchComponent from './../etch-component'
+
+export default class TagsDialog extends EtchComponent {
+  constructor (props) {
+    super(props)
+    this.tags = []
+    this.useSnakeCase = true
+
+    this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(atom.commands.add(this.element, 'core:cancel', () => { this.cancel() }))
+    this.subscriptions.add(atom.commands.add(this.element, 'core:confirm', () => { this.confirm() }))
+
+    this.panel = null
+    this.onAccept = null
+
+    etch.update(this)
+  }
+
+  render () {
+    const icon = this.props.mode === 'Add' ? 'icon icon-tag-add' : 'icon icon-tag-remove'
+    const tags = this.tags && this.tags.length
+      ? this.tags.map(this.makeListItem)
+      : null
+    const radioButtons = this.props.mode === 'Add'
+      ? (
+        <div className='case-radio-buttons'>
+          <label>Case: </label>
+          <label className='input-label'><input className='input-radio' type='radio' name='caseRadio' onchange={() => this.caseChanged()} ref='snakeCaseRadio' checked /> snake_case</label>
+          <label className='input-label'><input className='input-radio' type='radio' name='caseRadio' onchange={() => this.caseChanged()} /> camelCase</label><br />
+          <label className='input-label'><input className='input-toggle' type='checkbox' ref='sortCheckbox' onchange={() => this.sortChanged()} /> Sort Tags</label>
+        </div>
+      )
+      : null
+
+    return (
+      <div className='gomodifytags'>
+        <h1><span className={icon}>{this.props.mode} Tags</span></h1>
+        <div className='go-tags-flex-container'>
+          <div className='tag'><TextEditor mini ref='tag' placeholderText='tag (eg. json)' /></div>
+          <div className='option'><TextEditor mini ref='option' placeholderText='option (eg. omitempty)' /></div>
+          <button className='btn icon icon-file-add add' onclick={() => this.addTag()}>Add</button>
+        </div>
+        {radioButtons}
+        {tags &&
+          <div className='go-tags-list'>
+            <h3>Tags to {this.props.mode}:</h3>
+            <ul>
+              {tags}
+            </ul>
+          </div>
+        }
+        <div className='block'>
+          <button className='btn' onclick={() => this.confirm()} ref='submitButton'>Submit</button>
+          <button className='btn' onclick={() => this.cancel()}>Cancel</button>
+        </div>
+      </div>
+    )
+  }
+
+  makeListItem (tag, index) {
+    let text = tag.tag
+    if (tag.option) {
+      text += ' (' + tag.option + ')'
+    }
+    return <li key={index}>{text}</li>
+  }
+
+  caseChanged () {
+    this.useSnakeCase = this.refs.snakeCaseRadio.checked
+  }
+
+  sortChanged () {
+    this.sortTags = this.refs.sortCheckbox.checked
+  }
+
+  addTag () {
+    const tag = this.refs.tag.getText()
+    const opt = this.refs.option.getText()
+    if (tag) {
+      this.tags.push({tag: tag, option: opt})
+      this.refs.tag.setText('')
+      this.refs.option.setText('')
+      this.update()
+      this.refs.tag.element.focus()
+    }
+  }
+
+  attach () {
+    this.subscriptions.add(atom.commands.add(this.element,
+      'gomodifytags:focus-next', () => this.focusNextElement(1)))
+    this.subscriptions.add(atom.commands.add(this.element,
+      'gomodifytags:focus-previous', () => this.focusNextElement(-1)))
+
+    this.panel = atom.workspace.addModalPanel({
+      item: this
+    })
+    this.refs.tag.element.focus()
+  }
+
+  confirm () {
+    if (this.onAccept) {
+      this.onAccept({
+        tags: this.tags,
+        useSnakeCase: this.useSnakeCase,
+        sortTags: this.sortTags
+      })
+    }
+    this.destroy()
+  }
+
+  focusNextElement (direction) {
+    const elements = [this.refs.tag.element, this.refs.option.element, this.refs.submitButton]
+    const focusedElement = elements.find((el) => el.classList.contains('is-focused'))
+    let focusedIndex = elements.indexOf(focusedElement)
+
+    focusedIndex += direction
+    if (focusedIndex >= elements.length) {
+      focusedIndex = 0
+    } else if (focusedIndex < 0) {
+      focusedIndex = elements.length - 1
+    }
+
+    elements[focusedIndex].focus()
+    if (elements[focusedIndex].getModel) {
+      elements[focusedIndex].getModel().selectAll()
+    }
+  }
+
+  cancel () {
+    this.destroy()
+  }
+
+  dispose () {
+    this.destroy()
+  }
+
+  destroy () {
+    super.destroy()
+    this.subscriptions.dispose()
+    this.subscriptions = null
+    this.tags = null
+    this.onAccept = null
+
+    if (this.panel) {
+      this.panel.destroy()
+      this.panel = null
+    }
+  }
+}

--- a/lib/tags/tags-dialog.js
+++ b/lib/tags/tags-dialog.js
@@ -12,9 +12,15 @@ export default class TagsDialog extends EtchComponent {
     this.tags = []
     this.useSnakeCase = true
 
+    this.tagRegex = /^[\w]*$/
+    this.optionRegex = /^[\w,]*$/
+
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.commands.add(this.element, 'core:cancel', () => { this.cancel() }))
     this.subscriptions.add(atom.commands.add(this.element, 'core:confirm', () => { this.confirm() }))
+
+    this.subscriptions.add(this.refs.tag.onDidStopChanging(() => this.checkInput(this.refs.tag, this.tagRegex)))
+    this.subscriptions.add(this.refs.option.onDidStopChanging(() => this.checkInput(this.refs.option, this.optionRegex)))
 
     this.panel = null
     this.onAccept = null
@@ -61,6 +67,14 @@ export default class TagsDialog extends EtchComponent {
         </div>
       </div>
     )
+  }
+
+  checkInput (editor, regex) {
+    if (regex.test(editor.getText())) {
+      editor.element.classList.remove('invalid-input-value')
+    } else {
+      editor.element.classList.add('invalid-input-value')
+    }
   }
 
   makeListItem (tag, index) {

--- a/spec/fixtures/gomodifytags/foo.go
+++ b/spec/fixtures/gomodifytags/foo.go
@@ -1,0 +1,6 @@
+package foo
+
+struct Bar {
+  QuickBrownFox int
+  LazyDog string
+}

--- a/spec/fixtures/gomodifytags/foo.go
+++ b/spec/fixtures/gomodifytags/foo.go
@@ -1,6 +1,6 @@
 package foo
 
-struct Bar {
-  QuickBrownFox int
-  LazyDog string
+type Bar struct {
+	QuickBrownFox int
+	LazyDog       string
 }

--- a/spec/tags/gomodifytags-spec.js
+++ b/spec/tags/gomodifytags-spec.js
@@ -1,0 +1,176 @@
+'use babel'
+/* eslint-env jasmine */
+
+import path from 'path'
+import fs from 'fs-plus'
+import {lifecycle} from './../spec-helpers'
+
+describe('gomodifytags', () => {
+  let gopath = null
+  let editor = null
+  let gomodifytags = null
+  let source = null
+  let target = null
+
+  beforeEach(() => {
+    runs(() => {
+      lifecycle.setup()
+
+      gopath = fs.realpathSync(lifecycle.temp.mkdirSync('gopath-'))
+      process.env.GOPATH = gopath
+    })
+
+    waitsForPromise(() => {
+      return lifecycle.activatePackage()
+    })
+
+    runs(() => {
+      const {mainModule} = lifecycle
+      mainModule.provideGoConfig()
+      mainModule.loadGoModifyTags()
+    })
+
+    waitsFor(() => {
+      gomodifytags = lifecycle.mainModule.gomodifytags
+      return gomodifytags
+    })
+
+    afterEach(() => {
+      lifecycle.teardown()
+    })
+  })
+
+  describe('when a file is open', () => {
+    beforeEach(() => {
+      runs(() => {
+        source = path.join(__dirname, '..', 'fixtures', 'gomodifytags')
+        target = path.join(gopath, 'src', 'gomodifytags')
+        fs.copySync(source, target)
+      })
+
+      waitsForPromise(() => {
+        return atom.workspace.open(path.join(target, 'foo.go')).then((e) => {
+          editor = e
+          return
+        })
+      })
+    })
+
+    describe('argument builder', () => {
+      let options
+
+      beforeEach(() => {
+        options = {
+          tags: [{tag: 'xml', option: null}, {tag: 'bson', option: null}],
+          useSnakeCase: true,
+          sortTags: false
+        }
+      })
+
+      it('includes the -file option', () => {
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        expect(args.length).toBeGreaterThan(1)
+        expect(args[0]).toBe('-file')
+        expect(args[1]).toBe('foo.go')
+      })
+
+      it('defaults to json if no tags are specified', () => {
+        editor.setCursorBufferPosition([4, 6])
+        options.tags = []
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        const i = args.indexOf('-add-tags')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('json')
+        expect(args.includes('-add-options')).toBe(false)
+      })
+
+      it('specifies tags correctly', () => {
+        editor.setCursorBufferPosition([4, 6])
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        const i = args.indexOf('-add-tags')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('xml,bson')
+      })
+
+      it('uses the -offset flag if there is no selection', () => {
+        editor.setCursorBufferPosition([4, 6])
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        expect(args.length).toBeGreaterThan(3)
+        expect(args[2]).toBe('-offset')
+        expect(args[3]).toBe(51)
+      })
+
+      it('uses the -line flag when there is a selection', () => {
+        editor.setSelectedBufferRange([[3, 2], [4, 6]])
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        expect(args.length).toBeGreaterThan(3)
+        expect(args[2]).toBe('-line')
+        expect(args[3]).toBe('4,5')
+      })
+
+      it('uses the -modified flag when the buffer is modified', () => {
+        editor.setCursorBufferPosition([4, 6])
+        editor.insertNewlineBelow()
+        expect(editor.isModified()).toBe(true)
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        expect(args.includes('-modified')).toBe(true)
+      })
+
+      it('uses the -transform flag when camel case is specified', () => {
+        options.useSnakeCase = false
+        editor.setCursorBufferPosition([4, 6])
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        const i = args.indexOf('-transform')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('camelcase')
+      })
+
+      it('uses the -sort flag when the sort option is enabled', () => {
+        options.sortTags = true
+        editor.setCursorBufferPosition([4, 6])
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        expect(args.includes('-sort')).toBe(true)
+      })
+
+      it('includes the -add-options flag if options were specified for add', () => {
+        editor.setCursorBufferPosition([4, 6])
+        options.tags = [{tag: 'bson', option: 'omitempty'}, {tag: 'xml', option: 'foo'}]
+        const args = gomodifytags.buildArgs(editor, options, 'Add')
+        let i = args.indexOf('-add-tags')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('bson,xml')
+
+        i = args.indexOf('-add-options')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('bson=omitempty,xml=foo')
+      })
+
+      it('uses the -clear-tags flag if no tags are specified for remove', () => {
+        editor.setCursorBufferPosition([4, 6])
+        options.tags = []
+        const args = gomodifytags.buildArgs(editor, options, 'Remove')
+        expect(args.includes('-clear-tags')).toBe(true)
+      })
+
+      it ('includes the -remove-tags flag if no options are specified for remove', () => {
+        editor.setCursorBufferPosition([4, 6])
+        options.tags = [{tag: 'json', option: null}]
+        const args = gomodifytags.buildArgs(editor, options, 'Remove')
+        expect(args.includes('-remove-options')).toBe(false)
+        const i = args.indexOf('-remove-tags')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('json')
+      })
+
+      it ('includes the -remove-options flag if options are specified for remove', () => {
+        editor.setCursorBufferPosition([4, 6])
+        options.tags = [{tag: 'json', option: 'omitempty'}]
+        const args = gomodifytags.buildArgs(editor, options, 'Remove')
+        expect(args.includes('-remove-tags')).toBe(false)
+        const i = args.indexOf('-remove-options')
+        expect(i).not.toBe(-1)
+        expect(args[i + 1]).toBe('json=omitempty')
+      })
+    })
+  })
+})

--- a/spec/tags/gomodifytags-spec.js
+++ b/spec/tags/gomodifytags-spec.js
@@ -152,7 +152,7 @@ describe('gomodifytags', () => {
         expect(args.includes('-clear-tags')).toBe(true)
       })
 
-      it ('includes the -remove-tags flag if no options are specified for remove', () => {
+      it('includes the -remove-tags flag if no options are specified for remove', () => {
         editor.setCursorBufferPosition([4, 6])
         options.tags = [{tag: 'json', option: null}]
         const args = gomodifytags.buildArgs(editor, options, 'Remove')
@@ -162,7 +162,7 @@ describe('gomodifytags', () => {
         expect(args[i + 1]).toBe('json')
       })
 
-      it ('includes the -remove-options flag if options are specified for remove', () => {
+      it('includes the -remove-options flag if options are specified for remove', () => {
         editor.setCursorBufferPosition([4, 6])
         options.tags = [{tag: 'json', option: 'omitempty'}]
         const args = gomodifytags.buildArgs(editor, options, 'Remove')

--- a/styles/gomodifytags.less
+++ b/styles/gomodifytags.less
@@ -1,0 +1,55 @@
+@import "ui-variables";
+
+@margin: .5 * @component-padding;
+
+.gomodifytags {
+  font-size: @font-size;
+
+  label {
+    font-size: 1.25 * @font-size;
+    padding-right: @component-padding;
+  }
+
+  .go-tags-flex-container {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      justify-content: flex-start;
+      align-content: stretch;
+      align-items: center;
+      vertical-align: middle;
+
+      button {
+        order: 0;
+        flex: 0 1 auto;
+        align-self: auto;
+        margin-bottom: 10px;
+      }
+
+      div {
+        order: 0;
+        flex: 2 1 auto;
+        align-self: auto;
+      }
+  }
+
+  .go-tags-list {
+    font-size: 16px;
+
+    h3 {
+      font-size: 115%;
+    }
+  }
+
+  .btn {
+    margin-right: @margin;
+    margin-left: @margin;
+  }
+
+  .case-radio-buttons {
+    .input-label {
+      padding-right: @component-padding;
+      padding-bottom: @component-padding;
+    }
+  }
+}

--- a/styles/gomodifytags.less
+++ b/styles/gomodifytags.less
@@ -27,6 +27,8 @@
       }
 
       div {
+        margin-left: 2px;
+        margin-right: 2px;
         order: 0;
         flex: 2 1 auto;
         align-self: auto;
@@ -50,6 +52,22 @@
     .input-label {
       padding-right: @component-padding;
       padding-bottom: @component-padding;
+    }
+  }
+
+  atom-text-editor[mini] {
+    &.invalid-input-value {
+      border-color: @text-color-error;
+      box-shadow: 0 0 0 1px @text-color-error;
+      background-color: mix(@text-color-error, @input-background-color, 10%);
+
+      .selection .region {
+        background-color: mix(@text-color-error, @input-background-color, 50%);
+      }
+
+      .cursor {
+        border-color: @text-color-error;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description 
This PR adds support for @fatih's new `gomodifytags` tool.  
![image](https://cloud.githubusercontent.com/assets/7527103/23095981/0e87fb1e-f5d1-11e6-9462-2397917a3fc1.png)

Two new commands are exposed: `golang:add-tags` and `golang:remove-tags`.  These can be used to automatically add/remove struct tags.  The UI offers options for specifying tags and their options, whether to use `snake_case` or `camelCase` for the tag names, and the ability to sort the tags.

A brief demo: (sorry about the super-speed gif)
![gomodifytags](https://cloud.githubusercontent.com/assets/7527103/23095975/e32d8fec-f5d0-11e6-8f0d-041eb4861612.gif)

## Behavior

The behavior is similar to that of [vim-go](https://github.com/fatih/vim-go/pull/1204).

If the cursor is inside a struct and there is no selection, the tool operates on the entire struct.
If there is a selection then the tool only operates on line(s) that are touched by the selection (you don't need to select the entire line).

### Add Tags

If no tags are given then `json` is the default.  You can specify options such as `omitempty` in the options field, but this is not required.

### Remove Tags

If no tags are given then _all_ tags (and any corresponding options) are removed.
If tag names are given, then only those tags (and their options) will be removed.
If both tag and option are specified, then only the option is removed and the tag remains.

## TODO:

- [x] Add specs
- [x] Use `gomodifytags`'s JSON output and apply the updates to the buffer (instead of allowing the tool to rewrite the file for us - in some cases Atom doesn't refresh the buffer when this happens)
- [x] Test more complex scenarios with tag options and file any issues upstream.
