### PR TITLE
:arrow-up: dependencies

### DIFF
--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -1,8 +1,7 @@
 'use babel'
 
 import {CompositeDisposable} from 'atom'
-import fs from 'fs'
-import fse from 'fs-extra'
+import fs from 'fs-extra'
 import path from 'path'
 import temp from 'temp'
 
@@ -115,7 +114,7 @@ class Builder {
       if (r.stdout && r.stdout.trim() !== '') {
         console.log('go test: (stdout) ' + r.stdout)
       }
-      fse.remove(tempdir, (e) => {
+      fs.remove(tempdir, (e) => {
         if (e) {
           if (e.handle) {
             e.handle()

--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -2,8 +2,8 @@
 
 import {CompositeDisposable} from 'atom'
 import fs from 'fs'
+import fse from 'fs-extra'
 import path from 'path'
-import rimraf from 'rimraf'
 import temp from 'temp'
 
 class Builder {
@@ -115,7 +115,7 @@ class Builder {
       if (r.stdout && r.stdout.trim() !== '') {
         console.log('go test: (stdout) ' + r.stdout)
       }
-      rimraf(tempdir, (e) => {
+      fse.remove(tempdir, (e) => {
         if (e) {
           if (e.handle) {
             e.handle()

--- a/lib/config/executor.js
+++ b/lib/config/executor.js
@@ -3,7 +3,7 @@
 import {BufferedProcess} from 'atom'
 import {spawnSync} from 'child_process'
 import {getenvironment} from './environment'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import path from 'path'
 import {getEditor, projectPath} from '../utils'
 

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -3,10 +3,10 @@
 import {CompositeDisposable} from 'atom'
 import _ from 'lodash'
 import fs from 'fs'
+import fse from 'fs-extra'
 import os from 'os'
 import parser from './gocover-parser'
 import path from 'path'
-import rimraf from 'rimraf'
 import temp from 'temp'
 import {getEditor, isValidEditor} from '../utils'
 
@@ -202,7 +202,7 @@ class Tester {
 
   removeTempDir () {
     if (this.tempDir) {
-      rimraf(this.tempDir, (e) => {
+      fse.remove(this.tempDir, (e) => {
         if (e) {
           if (e.handle) {
             e.handle()

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -2,8 +2,7 @@
 
 import {CompositeDisposable} from 'atom'
 import _ from 'lodash'
-import fs from 'fs'
-import fse from 'fs-extra'
+import fs from 'fs-extra'
 import os from 'os'
 import parser from './gocover-parser'
 import path from 'path'
@@ -202,7 +201,7 @@ class Tester {
 
   removeTempDir () {
     if (this.tempDir) {
-      fse.remove(this.tempDir, (e) => {
+      fs.remove(this.tempDir, (e) => {
         if (e) {
           if (e.handle) {
             e.handle()

--- a/package.json
+++ b/package.json
@@ -55,17 +55,16 @@
     ]
   },
   "dependencies": {
-    "ansi-to-html": "^0.5.0",
+    "ansi-to-html": "^0.6.0",
     "etch": "^0.8.0",
     "etch-octicon": "^0.1.0",
     "fs-plus": "^2.9.3",
     "lodash": "^4.17.4",
-    "rimraf": "^2.5.4",
     "semver": "^5.3.0",
     "temp": "^0.8.3"
   },
   "devDependencies": {
-    "fs-extra": "^1.0.0",
+    "fs-extra": "^2.0.0",
     "standard": "^8.6.0"
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -58,13 +58,12 @@
     "ansi-to-html": "^0.6.0",
     "etch": "^0.8.0",
     "etch-octicon": "^0.1.0",
-    "fs-plus": "^2.9.3",
+    "fs-extra": "^2.0.0",
     "lodash": "^4.17.4",
     "semver": "^5.3.0",
     "temp": "^0.8.3"
   },
   "devDependencies": {
-    "fs-extra": "^2.0.0",
     "standard": "^8.6.0"
   },
   "providedServices": {

--- a/spec/doc/godoc-spec.js
+++ b/spec/doc/godoc-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import path from 'path'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import {lifecycle} from './../spec-helpers'
 
 describe('godoc', () => {

--- a/spec/navigator/godef-spec.js
+++ b/spec/navigator/godef-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import path from 'path'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import {lifecycle} from './../spec-helpers'
 
 describe('go to definition', () => {

--- a/spec/rename/gorename-spec.js
+++ b/spec/rename/gorename-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import path from 'path'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import {lifecycle} from './../spec-helpers'
 
 describe('gorename', () => {

--- a/spec/tags/gomodifytags-spec.js
+++ b/spec/tags/gomodifytags-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import path from 'path'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import {lifecycle} from './../spec-helpers'
 
 describe('gomodifytags', () => {

--- a/spec/test/gocover-parser-spec.js
+++ b/spec/test/gocover-parser-spec.js
@@ -1,7 +1,8 @@
 'use babel'
 /* eslint-env jasmine */
+
 import {ranges} from './../../lib/test/gocover-parser'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
 import _ from 'lodash'
@@ -33,6 +34,8 @@ describe('gocover-parser', () => {
       env['GOPATH'] = directory
       filePath = path.join(directory, 'src', 'github.com', 'testuser', 'example', 'go-plus.go')
       testFilePath = path.join(directory, 'src', 'github.com', 'testuser', 'example', 'go-plus_test.go')
+      fs.ensureDirSync(path.dirname(filePath))
+      fs.ensureDirSync(path.dirname(testFilePath))
       fs.writeFileSync(filePath, 'package main\n\nimport "fmt"\n\nfunc main()  {\n\tfmt.Println(Hello())\n}\n\nfunc Hello() string {\n\treturn "Hello, 世界"\n}\n')
       fs.writeFileSync(testFilePath, 'package main\n\nimport "testing"\n\nfunc TestHello(t *testing.T) {\n\tresult := Hello()\n\tif result != "Hello, 世界" {\n\t\tt.Errorf("Expected %s - got %s", "Hello, 世界", result)\n\t}\n}')
     })

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import path from 'path'
-import fs from 'fs-plus'
+import fs from 'fs-extra'
 import {lifecycle} from './../spec-helpers'
 
 describe('tester', () => {
@@ -49,6 +49,8 @@ describe('tester', () => {
       atom.config.set('go-plus.test.runTestsOnSave', false)
       filePath = path.join(gopath, 'src', 'github.com', 'testuser', 'example', 'go-plus.go')
       testFilePath = path.join(gopath, 'src', 'github.com', 'testuser', 'example', 'go-plus_test.go')
+      fs.ensureDirSync(path.dirname(filePath))
+      fs.ensureDirSync(path.dirname(testFilePath))
       fs.writeFileSync(filePath, '')
       fs.writeFileSync(testFilePath, '')
       waitsForPromise(() => {


### PR DESCRIPTION
Remove dependency on rimraf since fs-extra's `remove` function
performs the same duties.

Closes #572, #567, #566, #553, #552