### PR TITLE
Add runTestsWithCoverage flag

### DIFF
--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -238,8 +238,11 @@ class Tester {
         return
       }
       this.running = true
+      const runTestsWithCoverage = atom.config.get('go-plus.test.runTestsWithCoverage')
       this.clearMarkersFromEditors()
-      this.createCoverageFile()
+      if (runTestsWithCoverage) {
+        this.createCoverageFile()
+      }
       let go = false
       let cover = false
       return this.goconfig.locator.findTool('go').then((cmd) => {
@@ -267,7 +270,10 @@ class Tester {
           executorOptions.timeout = 60000
         }
         const cmd = go
-        const args = ['test', '-timeout=' + executorOptions.timeout + 'ms', '-coverprofile=' + this.coverageFile]
+        const args = ['test', '-timeout=' + executorOptions.timeout + 'ms']
+        if (runTestsWithCoverage) {
+          args.push('-coverprofile=' + this.coverageFile)
+        }
         if (atom.config.get('go-plus.test.runTestsWithShortFlag')) {
           args.push('-short')
         }
@@ -285,8 +291,10 @@ class Tester {
           }
 
           if (r.exitcode === 0) {
-            this.ranges = parser.ranges(this.coverageFile)
-            this.addMarkersToEditors()
+            if (runTestsWithCoverage) {
+              this.ranges = parser.ranges(this.coverageFile)
+              this.addMarkersToEditors()
+            }
             if (this.testPanelManager) {
               this.testPanelManager.update({exitcode: r.exitcode, output: output.trim(), state: 'success'})
             }

--- a/package.json
+++ b/package.json
@@ -397,19 +397,26 @@
           "default": 60000,
           "order": 2
         },
+        "runTestsWithCoverage": {
+          "title": "Run Tests With Coverage",
+          "description": "Runs `go test` with `-coverprofile` flag set, enabling coverage to be shown in the editor",
+          "type": "boolean",
+          "default": true,
+          "order": 3
+        },
         "runTestsWithShortFlag": {
           "title": "Run Tests With Short Flag Set",
           "description": "Runs `go test` with `-short` flag set",
           "type": "boolean",
           "default": true,
-          "order": 3
+          "order": 4
         },
         "runTestsWithVerboseFlag": {
           "title": "Run Tests With Verbose Flag Set",
           "description": "Runs `go test` with `-v` flag set",
           "type": "boolean",
           "default": false,
-          "order": 4
+          "order": 5
         },
         "coverageHighlightMode": {
           "title": "Coverage Highlight Mode",
@@ -422,7 +429,7 @@
             "uncovered",
             "disabled"
           ],
-          "order": 5
+          "order": 6
         },
         "coverageDisplayMode": {
           "title": "Coverage Display Mode",
@@ -433,14 +440,14 @@
             "highlight",
             "gutter"
           ],
-          "order": 6
+          "order": 7
         },
         "focusPanelIfTestsFail": {
           "title": "Focus The go-plus Panel If Tests Fail",
           "description": "If the panel is hidden, or the panel is showing a different tab, the panel will be expanded and the test tab focused when tests fail.",
           "type": "boolean",
           "default": true,
-          "order": 7
+          "order": 8
         }
       }
     }


### PR DESCRIPTION
- Allows the user to disable coverage while still running tests

This is helpful when printing log output, and you want to see accurate source lines:

```
log.SetFlags(log.Llongfile)
log.Printf("hello world")
```

Coverage performs source rewriting to collect coverage information, which throws the line numbers off.

Fixes #588