### PR TITLE
added autocomplete-plus descriptions and URL

### DIFF
--- a/lib/autocomplete/gocodeprovider.js
+++ b/lib/autocomplete/gocodeprovider.js
@@ -237,12 +237,21 @@ class GocodeProvider {
     } catch (e) {
       console.log(e)
     }
+
+    var pkg = editor.getTextInBufferRange([[position.row, 0], [position.row + 1, position.column]]);
+    pkg = pkg.substring(0, pkg.lastIndexOf(".")).replace(".", " ")
+
     const suggestions = []
     for (const c of candidates) {
+      var parse = spawnSync('atomParse', [pkg + " " + c.name]); // TODO: Make this async.
+      var doc = parse.stdout.toString().trim()
+
       let suggestion = {
         replacementPrefix: prefix,
         leftLabel: c.type || c.class,
-        type: this.translateType(c.class)
+        type: this.translateType(c.class),
+        description: doc,
+        descriptionMoreURL: "https://godoc.org/" + pkg.replace(" ", "/") + "#" + c.name
       }
       if (c.class === 'func' && (!suffix || suffix !== '(')) {
         suggestion = this.upgradeSuggestion(suggestion, c)

--- a/lib/autocomplete/gocodeprovider.js
+++ b/lib/autocomplete/gocodeprovider.js
@@ -2,6 +2,7 @@
 
 import {CompositeDisposable} from 'atom'
 import {isValidEditor} from '../utils'
+import {spawnSync} from 'child_process' // TODO: Properly implement
 import _ from 'lodash'
 import os from 'os'
 


### PR DESCRIPTION
It finally works now: https://i.imgur.com/zR45JdV.png
I am calling atomParse which is this package here: https://github.com/fasa123/atomParse You can gladly implement that one directly into the go-plus package it rather should just be a quick fix. But it works very well. The URL thing also works. 

Only thing that could be done is executing atomParse asynchronously. Currently it can take couple seconds to load the docs for a huge package which really does not feel nice. But I could not figure out how to do that without blocking the UI and still waiting for the docs. Best bet would be to split it up so only load the docs for the currently selected autocomplete item if thats possible.