### PR TITLE
Do not use different DOM nodes as the root for the usage view

### DIFF
--- a/lib/implements/implements-view.js
+++ b/lib/implements/implements-view.js
@@ -37,7 +37,6 @@ export default class ImplementsView extends EtchComponent {
     // obj.to: present for implementations of a queried interface
     // obj.from: present for interfaces implemented by the queried type
     // obj.fromptr: present for interfaces implemented by pointers to the queried type
-    console.log(obj)
     return (
       <div style={'width: 100%;'}>
         {obj.to && obj.to.length ? this.to(obj) : null}
@@ -101,7 +100,6 @@ export default class ImplementsView extends EtchComponent {
   }
 
   render () {
-    console.log('props', this.props)
     if (typeof this.props === 'string') {
       return <div className='padded-content'>{this.props}</div>
     }

--- a/lib/usage/usage-view.js
+++ b/lib/usage/usage-view.js
@@ -40,7 +40,7 @@ export default class UsageView extends EtchComponent {
 
   structuredContent (style, packs) {
     return (
-      <span ref='content' style={style} tabIndex='-1'>
+      <div ref='content' style={style} tabIndex='-1'>
         {packs.map(([pkg, refs]) => {
           return (
             <details className='go-plus-accordion-item' open>
@@ -59,7 +59,7 @@ export default class UsageView extends EtchComponent {
             </details>
           )
         })}
-      </span>
+      </div>
     )
   }
 


### PR DESCRIPTION
Having a look into etch shows that this isn't even supported: https://github.com/atom/etch/blob/v0.12.3/lib/component-helpers.js#L95-L97

Also got rid of unnecessary `console.log`s

fixes #631 