### PR TITLE
Show time-out message when build times out

### DIFF
--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -69,11 +69,19 @@ class Builder {
           for (const result of results) {
             if (result.exitcode !== 0) {
               if (that.output) {
-                that.output.update({
-                  exitcode: result.exitcode,
-                  output: result.output,
-                  dir: options.cwd
-                })
+                if (result.exitcode === 124) {
+                  that.output.update({
+                    exitcode: result.exitcode,
+                    output: `${result.linterName} timed out after ${options.timeout} ms.`,
+                    dir: options.cwd
+                  })
+                } else {
+                  that.output.update({
+                    exitcode: result.exitcode,
+                    output: result.output,
+                    dir: options.cwd
+                  })
+                }
               }
               reject(new Error(result.output))
               return


### PR DESCRIPTION
Fix for #644 

1. `result.output` needs additional checking otherwise an empty string `""` results in `true`
2. If `result.output` is empty check if errorcode 124 is present, if so show time-out message

Note that the line (just after this fix)
```
return Promise.reject(new Error(result.output));
```
results in `builder.js [sm]:84 Uncaught (in promise) Error:` in the developer console.

I am no go-plus/promises expert, so I am unable to fix this... (so feel free to fix this in this PR if you actually know what is happening :wink: )