### PR TITLE
Add command to toggle the config for running tests with coverage

### DIFF
--- a/keymaps/go-plus.json
+++ b/keymaps/go-plus.json
@@ -5,6 +5,7 @@
     "ctrl-alt-shift-g u": "golang:update-tools"
   },
   "atom-text-editor[data-grammar~=\"go\"]:not([mini])": {
+    "ctrl-alt-shift-g c": "golang:toggle-run-with-coverage",
     "ctrl-alt-shift-g f": "golang:gofmt",
     "ctrl-alt-shift-g i": "golang:goimports",
     "ctrl-alt-shift-g k": "golang:add-tags",

--- a/keymaps/go-plus.json
+++ b/keymaps/go-plus.json
@@ -5,7 +5,7 @@
     "ctrl-alt-shift-g u": "golang:update-tools"
   },
   "atom-text-editor[data-grammar~=\"go\"]:not([mini])": {
-    "ctrl-alt-shift-g c": "golang:toggle-run-with-coverage",
+    "ctrl-alt-shift-g c": "golang:toggle-test-with-coverage",
     "ctrl-alt-shift-g f": "golang:gofmt",
     "ctrl-alt-shift-g i": "golang:goimports",
     "ctrl-alt-shift-g k": "golang:add-tags",

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -44,7 +44,7 @@ class Tester {
   }
 
   handleCommands () {
-    this.subscriptions.add(atom.commands.add('atom-workspace', 'golang:toggle-run-with-coverage', () => {
+    this.subscriptions.add(atom.commands.add('atom-workspace', 'golang:toggle-test-with-coverage', () => {
       const current = atom.config.get('go-plus.test.runTestsWithCoverage')
       if (current) {
         atom.config.set('go-plus.test.runTestsWithCoverage', false)

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -45,12 +45,7 @@ class Tester {
 
   handleCommands () {
     this.subscriptions.add(atom.commands.add('atom-workspace', 'golang:toggle-test-with-coverage', () => {
-      const current = atom.config.get('go-plus.test.runTestsWithCoverage')
-      if (current) {
-        atom.config.set('go-plus.test.runTestsWithCoverage', false)
-      } else {
-        atom.config.set('go-plus.test.runTestsWithCoverage', false)
-      }
+      atom.config.set('go-plus.test.runTestsWithCoverage', !atom.config.get('go-plus.test.runTestsWithCoverage'))
     }))
     this.subscriptions.add(atom.commands.add('atom-workspace', 'golang:run-tests', () => {
       if (!getEditor()) {

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -44,6 +44,14 @@ class Tester {
   }
 
   handleCommands () {
+    this.subscriptions.add(atom.commands.add('atom-workspace', 'golang:toggle-run-with-coverage', () => {
+      const current = atom.config.get('go-plus.test.runTestsWithCoverage')
+      if (current) {
+        atom.config.set('go-plus.test.runTestsWithCoverage', false)
+      } else {
+        atom.config.set('go-plus.test.runTestsWithCoverage', false)
+      }
+    }))
     this.subscriptions.add(atom.commands.add('atom-workspace', 'golang:run-tests', () => {
       if (!getEditor()) {
         return

--- a/spec/tags/gomodifytags-spec.js
+++ b/spec/tags/gomodifytags-spec.js
@@ -5,7 +5,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import {lifecycle} from './../spec-helpers'
 
-fdescribe('gomodifytags', () => {
+describe('gomodifytags', () => {
   let gopath = null
   let editor = null
   let gomodifytags = null


### PR DESCRIPTION
I toggle the config for `go-plus.test.runTestsWithCoverage` enough times each day that I found myself annoyed at having to open Atom settings to toggle the config. 

This PR adds a command (`golang:toggle-test-with-coverage`) and a keybinding (<kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>g</kbd>&nbsp;&nbsp;<kbd>c</kbd>) to run the command.