### PR TITLE
add option to disable compilation on save

### DIFF
--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -42,6 +42,9 @@ class Builder {
   }
 
   build (editor, path = editor.getPath()) {
+    if (!atom.config.get('go-plus.config.compileOnSave')) {
+      return Promise.resolve()
+    }
     const that = this
     return new Promise((resolve, reject) => {
       if (!isValidEditor(editor)) {

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -77,7 +77,7 @@ class Tester {
   }
 
   handleSaveEvent (editor, path) {
-    if (atom.config.get('go-plus.test.runTestsOnSave')) {
+    if (atom.config.get('go-plus.config.compileOnSave') && atom.config.get('go-plus.test.runTestsOnSave')) {
       return this.runTests(editor)
     }
     return Promise.resolve()

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -77,7 +77,7 @@ class Tester {
   }
 
   handleSaveEvent (editor, path) {
-    if (atom.config.get('go-plus.config.compileOnSave') && atom.config.get('go-plus.test.runTestsOnSave')) {
+    if (atom.config.get('go-plus.test.runTestsOnSave')) {
       return this.runTests(editor)
     }
     return Promise.resolve()

--- a/package.json
+++ b/package.json
@@ -203,6 +203,13 @@
           "type": "string",
           "default": "",
           "order": 1
+        },
+        "compileOnSave": {
+          "title": "Compile on Save",
+          "description": "Compile the current package when a file is saved and provide linter errors.",
+          "type": "boolean",
+          "default": true,
+          "order": 2
         }
       }
     },

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -66,7 +66,7 @@ describe('tester', () => {
   })
 
   describe('when run tests on save is enabled, but compile on save is disabled', () => {
-    it('does not run tests', () => {
+    it('runs tests', () => {
       let buffer
       let testBuffer
 
@@ -93,7 +93,7 @@ describe('tester', () => {
       })
 
       runs(() => {
-        expect(tester.runTests).not.toHaveBeenCalled()
+        expect(tester.runTests).toHaveBeenCalled()
       })
     })
   })


### PR DESCRIPTION
Add option `go-plus.config.compileOnSave` that defaults to true.

When disabled, go plus will not attempt to build your code when a file is saved.
In this mode, go-plus will only format the file on save, which can be helpful if for some reason local compilation would fail (see #674).

Additionally, we make the assumption that if the user doesn't want to compile on save, they also don't want to test on save (if local compilation would fail, local test runs would also fail), and so we never run tests on save if compile on save is disabled.