### PR TITLE
Show test coverage if go test’s exit code is non-zero

### DIFF
--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -271,18 +271,17 @@ class Tester {
 
         output = output.trim()
         let state
-
         if (r.exitcode === 0) {
-          if (runTestsWithCoverage) {
-            this.ranges = parser.ranges(this.coverageFile)
-            this.addMarkersToEditors()
-          }
           state = 'success'
         } else if (r.exitcode === 124) {
           state = 'fail'
           output = output + os.EOL + 'Tests timed out after ' + atom.config.get('go-plus.test.timeout') + 'ms'
         } else {
           state = 'fail'
+        }
+        if (runTestsWithCoverage) {
+          this.ranges = parser.ranges(this.coverageFile)
+          this.addMarkersToEditors()
         }
         if (this.output) {
           this.output.update({


### PR DESCRIPTION
The current behavior is to only show coverage when tests fail. This is an unnecessary restriction - we should allow coverage to be shown whenever the coverage file contains valid information.

Note: This does not allow coverage to be shown for a focused [ginkgo](https://github.com/onsi/ginkgo) spec, as the coverage file does not appear to be generated when any focusing occurs. See https://github.com/onsi/ginkgo/issues/205 for more details 😢.