### PR TITLE
WIP: show descriptions in autocomplete suggestions

### DIFF
--- a/lib/autocomplete/gocodeprovider.js
+++ b/lib/autocomplete/gocodeprovider.js
@@ -199,15 +199,17 @@ class GocodeProvider {
           if (r.stderr && r.stderr.trim() !== '') {
             console.log('autocomplete-go: (stderr) ' + r.stderr)
           }
-          let messages
+          let p = Promise.resolve()
           if (r.stdout && r.stdout.trim() !== '') {
-            messages = this.mapMessages(r.stdout, options.editor, options.bufferPosition)
+            p = this.mapMessages(r.stdout, options.editor, options.bufferPosition)
           }
-          if (!messages || messages.length < 1) {
-            return resolve()
-          }
-          this.currentSuggestions = messages
-          resolve(messages)
+          p.then((suggestions) => {
+            if (!suggestions || suggestions.length < 1) {
+              return resolve()
+            }
+            this.currentSuggestions = suggestions
+            resolve(suggestions)
+          })
         }).catch((e) => {
           console.log(e)
           resolve()
@@ -235,7 +237,7 @@ class GocodeProvider {
 
   mapMessages (data, editor, position) {
     if (!data) {
-      return []
+      return Promise.resolve([])
     }
     let res
     try {
@@ -249,13 +251,13 @@ class GocodeProvider {
         dismissable: true
       })
       console.log(e)
-      return []
+      return Promise.resolve([])
     }
 
     const numPrefix = res[0]
     const candidates = res[1]
     if (!candidates) {
-      return []
+      return Promise.resolve([])
     }
     if (candidates[0] && candidates[0].class === 'PANIC' && candidates[0].type === 'PANIC' && candidates[0].name === 'PANIC') {
       this.bounceGocode()
@@ -267,6 +269,7 @@ class GocodeProvider {
     } catch (e) {
       console.log(e)
     }
+    const promises = []
     const suggestions = []
     for (const c of candidates) {
       let suggestion = {
@@ -283,9 +286,12 @@ class GocodeProvider {
       if (suggestion.type === 'package') {
         suggestion.iconHTML = '<i class="icon-package"></i>'
       }
+      if (c.package) {
+        promises.push(this.getDescription(suggestion, c))
+      }
       suggestions.push(suggestion)
     }
-    return suggestions
+    return Promise.all(promises).then(() => suggestions)
   }
 
   translateType (type) {
@@ -691,6 +697,32 @@ class GocodeProvider {
           notification.dismiss()
         }
       }]
+    })
+  }
+
+  getDescription (suggestion, candidate) {
+    return this.goconfig.locator.findTool('go').then((cmd) => {
+      if (!cmd) {
+        return
+      }
+
+      // add -u to get unexported fields too in order to get
+      // the description for funcs/vars in the current package
+      const args = ['doc', '-u', candidate.package]
+      // skip the "name" for the "package" class because
+      // they already have the correct name in "package"
+      if (candidate.class !== 'package') {
+        args.push(candidate.name)
+      }
+
+      return this.goconfig.executor.exec(cmd, args).then((r) => {
+        if (r.stderr && r.stderr.trim() !== '') {
+          console.log('autocomplete-go: stderr while getting godoc for ' + candidate.package + ' ' + candidate.name + ': ' + r.stderr)
+        }
+        if (r.exitcode === 0) {
+          suggestion.description = r.stdout.trim()
+        }
+      })
     })
   }
 }


### PR DESCRIPTION
🚨 **WIP: do not merge** 🚨 

I've tried the [PR for gocode](https://github.com/nsf/gocode/pull/463) that adds a `package` property to it's suggestions.
This PR tries to add the actual description of the symbol to the autocomplete suggestion (requested in #542)

![image](https://user-images.githubusercontent.com/3003233/29374985-ae1296ac-82b3-11e7-9ddc-f34c20507c34.png)

**Turns out it helps us, but it is definitely not the solution we want!**

I'm just leaving this PR here so that I've at least documented my findings somewhere :)

-----

**Problem 1**

We would still have to load all descriptions at once because autocomplete-plus does not support "lazy" loading of the description. Which puts quite some pressure on the computer (e.g. just trying to autocomplete `time.` takes several seconds to finish)
I even tried to outsmart them by using [property getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) for the `description` field, but they are accessing _all_ descriptions even before it is actually displayed, so no chance...

**Problem 2**

It is currently not possible to distinguish exported functions on structs and exported functions for the package if they have the same name. It's because we are only getting the name of the package but not the type of the struct we are currently getting suggestions for:
```go
package person

// Person represents a person
type Person struct{}

// Hello says hello person
func (ta Person) Hello() {}

// Hello says hello package
func Hello() {}
```

```go
package main

import "person"

func main() {
    person. // <- autocomplete here shows "says hello package"

    p := person.Person{}
    p. // <- also shows "says hello package" here!
}

```

**Problem 3**

Most of the standard go packages heavily use space indented comments to get some formatting into them.
Apparently this is not supported by autocomplete-plus yet.
We have to wait for https://github.com/atom/autocomplete-plus/commit/776f037dc214631d765dbdb8da56a561990e4ead to be shipped with atom.

Also once this has been added to atom, the description still sometimes wraps to a new line which is hard to read (especially for "formatted" documentation)

![image](https://user-images.githubusercontent.com/3003233/29375123-344f221c-82b4-11e7-9ca4-05febe2741b9.png)


**Problem 4**

As you can see in the pictures above, the "signature" of the function (so `func Fprintf(....` is also shown in the description. Even though it would not be necessary because it is actually already visible in the rest of the suggestions anyway.
Unfortunately trying to get rid of the "signature" of the symbol we are asking `go doc` gets really complicated. The problem is that there are a variety of signatures that we would have to detect and get rid of.
e.g. Let's have a look at various go doc calls
```
$ go doc fmt Printf
func Printf(format string, a ...interface{}) (n int, err error)
    Printf formats according to a format specifier and writes to standard
    output. It returns the number of bytes written and any write error
    encountered.


$ go doc fmt Printf
type Stringer interface {
        String() string
}
    Stringer is implemented by any value that has a String method, which defines
    the ``native'' format for that value. The String method is used to print
    values passed as an operand to any format that accepts a string or to an
    unformatted printer such as Print.


$ go doc time UnixDate
const (
        ANSIC       = "Mon Jan _2 15:04:05 2006"
        UnixDate    = "Mon Jan _2 15:04:05 MST 2006"
        RubyDate    = "Mon Jan 02 15:04:05 -0700 2006"
        RFC822      = "02 Jan 06 15:04 MST"
        RFC822Z     = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
        // ... more consts here
)
    These are predefined layouts for use in Time.Format and Time.Parse. The
    reference time used in the layouts is the specific time:

    // ... more text here
```
I'm pretty sure I have not found all styles, but as you can see it could get pretty hard to parse all these different styles in order to get rid of the signature.

Fixes #351 
