### PR TITLE
autocomplete unimported packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - go get -u github.com/rogpeppe/godef
   - go get -u github.com/fatih/gomodifytags
   - go get -u golang.org/x/tools/cmd/guru
+  - go get -u github.com/tpng/gopkgs
 
 script:
   - 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ install:
   - go get -u github.com/rogpeppe/godef
   - go get -u github.com/fatih/gomodifytags
   - go get -u golang.org/x/tools/cmd/guru
+  - go get -u github.com/tpng/gopkgs
 
 build_script:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))

--- a/lib/autocomplete/gocodeprovider-helper.js
+++ b/lib/autocomplete/gocodeprovider-helper.js
@@ -1,0 +1,97 @@
+'use babel'
+
+import path from 'path'
+
+const vendorString = '/vendor/'
+
+export function wantedPackage (buffer, pos) {
+  // get the pkg the user tries to autocomplete from the current line
+  const lineTillPos = buffer.getTextInRange([[pos.row, 0], pos])
+  const matches = lineTillPos.match(/(\w+)\.$/)
+  if (!matches) {
+    return null
+  }
+  return matches[1]
+}
+
+export function addImport (buffer, pkg, offset) {
+  // find the "package ..." statement
+  let row = -1
+  buffer.scan(/^package /, (result) => {
+    row = result.row
+  })
+  if (row === -1) {
+    return null
+  }
+
+  const text = buffer.getText()
+
+  // import the "pkg" right after the package statement
+  const importStmt = `import "${pkg}"\n`
+  const index = buffer.characterIndexForPosition([row + 1, 0])
+  const newText = text.substr(0, index) + importStmt + text.substr(index)
+  const newOffset = offset + importStmt.length
+  return { text: newText, offset: newOffset }
+}
+
+export function getPackage (file, gopath, pkgs, useVendor) {
+  if (useVendor) {
+    const dir = path.dirname(file)
+    const workspace = getCurrentGoWorkspaceFromGOPATH(gopath, dir)
+    const vendorPkgs = pkgs.filter((pkg) => pkg.lastIndexOf(vendorString) > 0)
+    for (const vpkg of vendorPkgs) {
+      const relativePath = getRelativePackagePath(dir, workspace, vpkg)
+      if (relativePath) {
+        return relativePath
+      }
+    }
+  }
+
+  // take the first non-vendor package
+  return pkgs.find((pkg) => pkg.lastIndexOf(vendorString) === -1)
+}
+
+export function getRelativePackagePath (currentDir, currentWorkspace, pkg) {
+  let magicVendorString = vendorString
+  let vendorIndex = pkg.lastIndexOf(magicVendorString)
+  if (vendorIndex === -1) {
+    magicVendorString = 'vendor/'
+    if (pkg.startsWith(magicVendorString)) {
+      vendorIndex = 0
+    }
+  }
+  // Check if current file and the vendor pkg belong to the same root project
+  // If yes, then vendor pkg can be replaced with its relative path to the "vendor" folder
+  // If not, then the vendor pkg should not be allowed to be imported.
+  if (vendorIndex > -1) {
+    let rootProjectForVendorPkg = path.join(currentWorkspace, pkg.substr(0, vendorIndex))
+    let relativePathForVendorPkg = pkg.substring(vendorIndex + magicVendorString.length)
+
+    if (relativePathForVendorPkg && currentDir.startsWith(rootProjectForVendorPkg)) {
+      return relativePathForVendorPkg
+    }
+    return ''
+  }
+
+  return pkg
+}
+
+export function getCurrentGoWorkspaceFromGOPATH (gopath, currentDir) {
+  let workspaces = gopath.split(path.delimiter)
+  let currentWorkspace = ''
+
+  // Find current workspace by checking if current file is
+  // under any of the workspaces in $GOPATH
+  for (let i = 0; i < workspaces.length; i++) {
+    let possibleCurrentWorkspace = path.join(workspaces[i], 'src')
+    if (currentDir.startsWith(possibleCurrentWorkspace)) {
+      // In case of nested workspaces, (example: both /Users/me and /Users/me/src/a/b/c are in $GOPATH)
+      // both parent & child workspace in the nested workspaces pair can make it inside the above if block
+      // Therefore, the below check will take longer (more specific to current file) of the two
+      if (possibleCurrentWorkspace.length > currentWorkspace.length) {
+        currentWorkspace = possibleCurrentWorkspace
+      }
+    }
+  }
+  return currentWorkspace
+}

--- a/lib/autocomplete/gocodeprovider.js
+++ b/lib/autocomplete/gocodeprovider.js
@@ -5,6 +5,8 @@ import {filter} from 'fuzzaldrin-plus'
 import _ from 'lodash'
 import os from 'os'
 import {isValidEditor} from '../utils'
+import {allPackages, isVendorSupported} from '../go'
+import {wantedPackage, getPackage, addImport} from './gocodeprovider-helper'
 
 class GocodeProvider {
   constructor (goconfig) {
@@ -54,6 +56,8 @@ class GocodeProvider {
       this.unimportedPackages = value
       this.toggleGocodeConfig()
     }))
+
+    this.allPkgs = allPackages(this.goconfig)
   }
 
   dispose () {
@@ -154,7 +158,7 @@ class GocodeProvider {
         return p
       }
     }
-    if (prefix.length > 1 && this.currentSuggestions.length) {
+    if (prefix.length > 0 && prefix !== '.' && this.currentSuggestions.length) {
       // fuzzy filter on this.currentSuggestions
       const p = new Promise((resolve) => {
         resolve(filter(this.currentSuggestions, prefix, {key: 'fuzzyMatch'})
@@ -166,22 +170,23 @@ class GocodeProvider {
 
     // get a fresh set of suggestions from gocode
     const p = new Promise((resolve) => {
-      if (!options || !this.ready() || !isValidEditor(options.editor)) {
+      const { editor, bufferPosition } = options
+      if (!options || !this.ready() || !isValidEditor(editor)) {
         return resolve()
       }
 
-      const buffer = options.editor.getBuffer()
-      if (!buffer || !options.bufferPosition) {
+      const buffer = editor.getBuffer()
+      if (!buffer || !bufferPosition) {
         return resolve()
       }
 
-      const index = buffer.characterIndexForPosition(options.bufferPosition)
-      const priorBufferPosition = options.bufferPosition.copy()
+      const index = buffer.characterIndexForPosition(bufferPosition)
+      const priorBufferPosition = bufferPosition.copy()
       if (priorBufferPosition.column > 0) {
         priorBufferPosition.column = priorBufferPosition.column - 1
       }
-      const scopeDescriptor = options.editor.scopeDescriptorForBufferPosition(priorBufferPosition)
-      const text = options.editor.getText()
+      const scopeDescriptor = editor.scopeDescriptorForBufferPosition(priorBufferPosition)
+      const text = editor.getText()
       if (!options.activatedManually && index > 0 && this.characterIsSuppressed(text[index - 1], scopeDescriptor)) {
         return resolve()
       }
@@ -192,31 +197,77 @@ class GocodeProvider {
           resolve()
           return false
         }
-        const args = ['-f=json', 'autocomplete', buffer.getPath(), offset]
-        const execOptions = this.goconfig.executor.getOptions('file', options.editor)
+        const file = buffer.getPath()
+        const args = ['-f=json', 'autocomplete', file, offset]
+        const execOptions = this.goconfig.executor.getOptions('file', editor)
         execOptions.input = text
-        this.goconfig.executor.exec(cmd, args, execOptions).then((r) => {
-          if (r.stderr && r.stderr.trim() !== '') {
-            console.log('autocomplete-go: (stderr) ' + r.stderr)
-          }
-          let messages
-          if (r.stdout && r.stdout.trim() !== '') {
-            messages = this.mapMessages(r.stdout, options.editor, options.bufferPosition)
-          }
-          if (!messages || messages.length < 1) {
-            return resolve()
-          }
-          this.currentSuggestions = messages
-          resolve(messages)
-        }).catch((e) => {
-          console.log(e)
-          resolve()
-        })
+
+        this.executeGocode(cmd, args, execOptions)
+          .then((rawSuggestions) => {
+            if (rawSuggestions.length === 0 && prefix === '.') {
+              return isVendorSupported(this.goconfig).then((useVendor) => {
+                const pkg = wantedPackage(buffer, bufferPosition)
+                if (!pkg) {
+                  return []
+                }
+                const pkgs = this.allPkgs.get(pkg)
+                if (!pkgs || !pkgs.length) {
+                  return []
+                }
+                const {GOPATH} = this.goconfig.environment()
+                const pkgPath = getPackage(file, GOPATH, pkgs, useVendor)
+                if (!pkgPath) {
+                  return []
+                }
+                const added = addImport(buffer, pkgPath, offset)
+                if (!added) {
+                  return []
+                }
+                const args = ['-f=json', 'autocomplete', file, added.offset]
+                const execOptions = this.goconfig.executor.getOptions('file', editor)
+                execOptions.input = added.text
+                return this.executeGocode(cmd, args, execOptions)
+              })
+            }
+            return rawSuggestions
+          })
+          .then((rawSuggestions) => {
+            const suggestions = this.mapMessages(rawSuggestions, editor, bufferPosition)
+            this.currentSuggestions = suggestions
+            resolve(suggestions)
+          })
       })
     })
 
     this.notifySubscribers(p)
     return p
+  }
+
+  executeGocode (cmd, args, options) {
+    return this.goconfig.executor.exec(cmd, args, options).then((r) => {
+      if (r.stderr && r.stderr.trim() !== '') {
+        console.log('go-plus: Failed to run gocode:', r.stderr)
+      }
+      const data = (r.stdout || '').trim()
+      if (!data) {
+        return []
+      }
+      try {
+        return JSON.parse(r.stdout)
+      } catch (e) {
+        if (e && e.handle) {
+          e.handle()
+        }
+        atom.notifications.addError('gocode error', {
+          detail: r.stdout,
+          dismissable: true
+        })
+        console.log('go-plus: Failed to parse the output of gocode:', e)
+        return []
+      }
+    }).catch((e) => {
+      console.log(e)
+    })
   }
 
   notifySubscribers (p) {
@@ -233,25 +284,7 @@ class GocodeProvider {
     }
   }
 
-  mapMessages (data, editor, position) {
-    if (!data) {
-      return []
-    }
-    let res
-    try {
-      res = JSON.parse(data)
-    } catch (e) {
-      if (e && e.handle) {
-        e.handle()
-      }
-      atom.notifications.addError('gocode error', {
-        detail: data,
-        dismissable: true
-      })
-      console.log(e)
-      return []
-    }
-
+  mapMessages (res, editor, position) {
     const numPrefix = res[0]
     const candidates = res[1]
     if (!candidates) {

--- a/lib/config/executor.js
+++ b/lib/config/executor.js
@@ -96,15 +96,17 @@ class Executor {
       }
 
       const bufferedprocess = new BufferedProcess({command: command, args: args, options: options, stdout: stdoutFn, stderr: stderrFn, exit: exitFn})
-      setTimeout(() => {
-        bufferedprocess.kill()
-        resolve({
-          error: null,
-          exitcode: 124,
-          stdout: stdout,
-          stderr: stderr
-        })
-      }, options.timeout)
+      if (options.timeout > 0) {
+        setTimeout(() => {
+          bufferedprocess.kill()
+          resolve({
+            error: null,
+            exitcode: 124,
+            stdout: stdout,
+            stderr: stderr
+          })
+        }, options.timeout)
+      }
       bufferedprocess.onWillThrowError((err) => {
         let e = err
         if (err) {

--- a/lib/go.js
+++ b/lib/go.js
@@ -1,0 +1,82 @@
+'use babel'
+
+let goVersion
+export function version (goconfig) {
+  if (goVersion) {
+    return Promise.resolve(goVersion)
+  }
+  return goconfig.locator.findTool('go').then((go) => {
+    const args = ['version']
+    return goconfig.executor.exec(go, args, 'project').then((r) => {
+      if (r.exitcode !== 0) {
+        console.log('go-plus: Failed to get "go version":', (r.stderr.trim()) || `exitcode ${r.exitcode}`)
+        return null
+      }
+      const raw = r.stdout.trim()
+      const matches = raw.match(/^go version go(\d)\.(\d+)/)
+      goVersion = {
+        raw,
+        major: parseInt(matches[1], 10),
+        minor: parseInt(matches[2], 10)
+      }
+      return goVersion
+    })
+  })
+}
+
+let vendorSupported
+export function isVendorSupported (goconfig) {
+  if (vendorSupported != null) {
+    return Promise.resolve(vendorSupported)
+  }
+  return version(goconfig).then(version => {
+    if (!version) {
+      return goconfig.environment()['GO15VENDOREXPERIMENT'] !== '0'
+    }
+
+    switch (version.major) {
+      case 0:
+        vendorSupported = false
+        break
+      case 1:
+        vendorSupported = (version.minor > 6 || ((version.minor === 5 || version.minor === 6) && goconfig.environment()['GO15VENDOREXPERIMENT'] !== '0'))
+        break
+      default:
+        vendorSupported = true
+        break
+    }
+    return vendorSupported
+  })
+}
+
+let pkgs
+export function allPackages (goconfig) {
+  if (pkgs) {
+    return pkgs
+  }
+  pkgs = new Map()
+
+  goconfig.locator.findTool('gopkgs').then((gopkgs) => {
+    if (!gopkgs) {
+      return
+    }
+    return goconfig.executor.exec(gopkgs, [], 'project').then((r) => {
+      if (r.exitcode !== 0) {
+        console.log('go-plus: "gopkgs" returned the following errors:', r.stderr.trim() || `exitcode ${r.exitcode}`)
+      }
+
+      r.stdout.trim()
+        .split('\n')
+        .forEach((path) => {
+          const name = path.trim().split('/').pop()
+          const p = pkgs.get(name) || []
+          pkgs.set(name, p.concat(path.trim()))
+        })
+
+      pkgs.forEach((p) => {
+        p.sort()
+      })
+    })
+  })
+  return pkgs
+}

--- a/lib/go.js
+++ b/lib/go.js
@@ -1,45 +1,22 @@
 'use babel'
 
-let goVersion
-export function version (goconfig) {
-  if (goVersion) {
-    return Promise.resolve(goVersion)
-  }
-  return goconfig.locator.findTool('go').then((go) => {
-    const args = ['version']
-    return goconfig.executor.exec(go, args, 'project').then((r) => {
-      if (r.exitcode !== 0) {
-        console.log('go-plus: Failed to get "go version":', (r.stderr.trim()) || `exitcode ${r.exitcode}`)
-        return null
-      }
-      const raw = r.stdout.trim()
-      const matches = raw.match(/^go version go(\d)\.(\d+)/)
-      goVersion = {
-        raw,
-        major: parseInt(matches[1], 10),
-        minor: parseInt(matches[2], 10)
-      }
-      return goVersion
-    })
-  })
-}
-
 let vendorSupported
 export function isVendorSupported (goconfig) {
   if (vendorSupported != null) {
     return Promise.resolve(vendorSupported)
   }
-  return version(goconfig).then(version => {
-    if (!version) {
+  return goconfig.locator.runtime().then((runtime) => {
+    if (!runtime) {
       return goconfig.environment()['GO15VENDOREXPERIMENT'] !== '0'
     }
+    const [major, minor] = runtime.semver.split('.')
 
-    switch (version.major) {
+    switch (major) {
       case 0:
         vendorSupported = false
         break
       case 1:
-        vendorSupported = (version.minor > 6 || ((version.minor === 5 || version.minor === 6) && goconfig.environment()['GO15VENDOREXPERIMENT'] !== '0'))
+        vendorSupported = (minor > 6 || ((minor === 5 || minor === 6) && goconfig.environment()['GO15VENDOREXPERIMENT'] !== '0'))
         break
       default:
         vendorSupported = true

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -33,7 +33,8 @@ const goTools = new Map([
   ['gogetdoc', 'github.com/zmb3/gogetdoc'],
   ['godef', 'github.com/rogpeppe/godef'],
   ['guru', 'golang.org/x/tools/cmd/guru'],
-  ['gomodifytags', 'github.com/fatih/gomodifytags']
+  ['gomodifytags', 'github.com/fatih/gomodifytags'],
+  ['gopkgs', 'github.com/tpng/gopkgs']
 ])
 
 class PackageManager {

--- a/spec/autocomplete/gocodeprovider-helper-spec.js
+++ b/spec/autocomplete/gocodeprovider-helper-spec.js
@@ -1,0 +1,92 @@
+'use babel'
+/* eslint-env jasmine */
+
+import {getPackage} from '../../lib/autocomplete/gocodeprovider-helper'
+import * as path from 'path'
+
+describe('gocodeprovider-helper', () => {
+  describe('getPackage', () => {
+    function normalize (v) {
+      return (process.platform === 'win32' ? 'C:' : '') + path.normalize(v)
+    }
+    it('returns a non-vendored package if `useVendor` is false', () => {
+      const pkg = getPackage(
+        normalize('/Users/me/go/src/github.com/foo/server/main.go'),
+        normalize('/Users/me/go'),
+        [
+          'github.com/foo/server/vendor/github.com/bar/lib',
+          'github.com/foo/lib'
+        ],
+        false // <-- vendor is not active
+      )
+      expect(pkg).toBe('github.com/foo/lib')
+    })
+
+    it('returns a vendored package if `useVendor` is true', () => {
+      const pkg = getPackage(
+        normalize('/Users/me/go/src/github.com/foo/server/main.go'),
+        normalize('/Users/me/go'),
+        [
+          'github.com/foo/server/vendor/github.com/bar/lib',
+          'github.com/foo/lib'
+        ],
+        true // <-- vendor is active
+      )
+      expect(pkg).toBe('github.com/bar/lib')
+    })
+
+    it('gets vendored package if inside sub package', () => {
+      const pkg = getPackage(
+        normalize('/Users/me/go/src/github.com/foo/server/sub/sub.go'), // <-- inside sub package
+        normalize('/Users/me/go'),
+        [
+          'github.com/foo/server/vendor/github.com/bar/lib',
+          'github.com/foo/lib'
+        ],
+        true
+      )
+      expect(pkg).toBe('github.com/bar/lib')
+    })
+
+    it('ignores nested vendored packages', () => {
+      const pkg = getPackage(
+        normalize('/Users/me/go/src/github.com/foo/server/main.go'),
+        normalize('/Users/me/go'),
+        [
+          'github.com/foo/server/vendor/github.com/bar/lib/vendor/github.com/baz/other'
+        ],
+        true
+      )
+      expect(pkg).toBeFalsy()
+    })
+
+    it('returns non-vendored package if vendor does not match', () => {
+      const pkg = getPackage(
+        normalize('/Users/me/go/src/github.com/foo/server/main.go'),
+        normalize('/Users/me/go'),
+        [
+          // ignores this package because it is inside the "bar" package not "foo"
+          'github.com/bar/server/vendor/github.com/baz/lib',
+          // returns this because no vendored package matches
+          'github.com/qux/lib'
+        ],
+        true
+      )
+      expect(pkg).toBe('github.com/qux/lib')
+    })
+
+    it('returns another vendored package inside a vendored package', () => {
+      const pkg = getPackage(
+        // a file inside a vendored package ...
+        normalize('/Users/me/go/src/github.com/foo/server/vendor/github.com/bar/lib/lib.go'),
+        normalize('/Users/me/go'),
+        [
+          // ... is allowed to use another vendored package
+          'github.com/foo/server/vendor/github.com/baz/other'
+        ],
+        true
+      )
+      expect(pkg).toBe('github.com/baz/other')
+    })
+  })
+})

--- a/spec/autocomplete/gocodeprovider-spec.js
+++ b/spec/autocomplete/gocodeprovider-spec.js
@@ -41,7 +41,7 @@ describe('gocodeprovider', () => {
       jasmine.attachToDOM(workspaceElement)
 
       // autocomplete-plus
-      autocompleteManager = autocompleteplusMain.getAutocompleteManager()
+      autocompleteManager = autocompleteplusMain.autocompleteManager
       spyOn(autocompleteManager, 'displaySuggestions').andCallThrough()
       spyOn(autocompleteManager, 'showSuggestionList').andCallThrough()
       spyOn(autocompleteManager, 'hideSuggestionList').andCallThrough()
@@ -888,6 +888,47 @@ describe('gocodeprovider', () => {
           expect(suggestions[0].type).toBe('function')
           expect(suggestions[0].leftLabel).toBe('(n int, err error)')
           editor.backspace()
+        })
+      })
+    })
+
+    describe('provides suggestions for unimported packages', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.autocomplete.snippetMode', 'nameAndType')
+      })
+
+      it('provides the exported types of the unimported package', () => {
+        let suggestions = null
+        runs(() => {
+          expect(provider).toBeDefined()
+          expect(provider.getSuggestions).not.toHaveBeenCalled()
+          expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
+          editor.setCursorScreenPosition([7, 0])
+
+          // get suggestions for package 'github.com/sqs/goreturns/returns'
+          editor.insertText('returns')
+          advanceClock(completionDelay)
+          editor.insertText('.')
+          advanceClock(completionDelay)
+        })
+
+        waitsFor(() => {
+          return provider.getSuggestions.calls.length === 1 && suggestionsPromise !== null
+        })
+
+        waitsForPromise(() => {
+          return suggestionsPromise.then((s) => {
+            suggestions = s
+          })
+        })
+
+        runs(() => {
+          expect(provider.getSuggestions).toHaveBeenCalled()
+          expect(provider.getSuggestions.calls.length).toBe(1)
+          expect(suggestions).toBeTruthy()
+          expect(suggestions.length).toBeGreaterThan(0)
+          expect(suggestions[0]).toBeTruthy()
+          expect(suggestions[0].displayText).toBe('Process(pkgDir string, filename string, src []byte, opt *returns.Options)')
         })
       })
     })


### PR DESCRIPTION
This is done by (temporarily) adding an `import "..."` statement into the code so that `gocode` can find the package and provide suggestions for it.

It is still rough on the edges especially for vendored packages.

Possible improvements:
* automatically add the `import "..."` when a suggestion is selected (nice to have, will be added by `goimports` on save anyway)
* the `pkg` map in `go.js` does not grow if new packages are added (low prio)

Fixes #665 