### PR TITLE
Use input text for "Add Tags" command when no opts specified.

### DIFF
--- a/lib/tags/tags-dialog.js
+++ b/lib/tags/tags-dialog.js
@@ -119,6 +119,9 @@ export default class TagsDialog extends EtchComponent {
   }
 
   confirm () {
+    if (this.tags.length === 0) {
+      this.addTag()
+    }
     if (this.onAccept) {
       this.onAccept({
         tags: this.tags,


### PR DESCRIPTION
Altered the "Add Tags" command to take any text in the input boxes and use that text if there are no other tags defined.

The change is intended to improve the user experience and decrease confusion whenever a user is adding a single custom struct tag that doesn't use default values (tag:"json", options:"").

Fixes #692

*Note: There aren't currently any tests for the `TestDialog` so there aren't any tests in this PR. I can try to add something, but my JS skills are limited and I'm not 100% familiar with the proper way to add a new test, especially one on a UI component. Testing in the [gomodifytags-spec.js](https://github.com/joefitzgerald/go-plus/blob/master/spec/tags/gomodifytags-spec.js) doesn't appear to be plausible since these tests seem to start after the `TestDialog` would have returned data.*