### PR TITLE
allow test coverage for symlinks

### DIFF
--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -117,7 +117,10 @@ class Tester {
       return
     }
 
-    const editorRanges = _.filter(this.ranges, (r) => { return _.endsWith(file, r.file.replace(/^_\//g, '')) })
+		const re = /[^/\\]+$/g;
+		const editorRanges = _.filter(this.ranges, (r) => {
+		    return file.match(re)[0] == r.file.match(re)[0] && !_.endsWith(file, "_test.go")
+		})
 
     if (!editorRanges || editorRanges.length <= 0) {
       return

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -117,10 +117,10 @@ class Tester {
       return
     }
 
-		const re = /[^/\\]+$/g;
-		const editorRanges = _.filter(this.ranges, (r) => {
-		    return file.match(re)[0] == r.file.match(re)[0] && !_.endsWith(file, "_test.go")
-		})
+    const re = /[^/\\]+$/g;
+    const editorRanges = _.filter(this.ranges, (r) => {
+      return file.match(re)[0] == r.file.match(re)[0] && !_.endsWith(file, "_test.go")
+    })
 
     if (!editorRanges || editorRanges.length <= 0) {
       return

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -117,9 +117,9 @@ class Tester {
       return
     }
 
-    const re = /[^/\\]+$/g;
+    const re = /[^/\\]+$/g
     const editorRanges = _.filter(this.ranges, (r) => {
-      return file.match(re)[0] == r.file.match(re)[0] && !_.endsWith(file, "_test.go")
+      return file.match(re)[0] === r.file.match(re)[0] && !_.endsWith(file, '_test.go')
     })
 
     if (!editorRanges || editorRanges.length <= 0) {

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -119,7 +119,7 @@ class Tester {
 
     const re = /[^/\\]+$/g
     const editorRanges = _.filter(this.ranges, (r) => {
-      return file.match(re)[0] === r.file.match(re)[0] && !_.endsWith(file, '_test.go')
+      return file.match(re)[0] === r.file.match(re)[0]
     })
 
     if (!editorRanges || editorRanges.length <= 0) {


### PR DESCRIPTION
/[^/\\]+$/g finds the filename given a Windows or OS X path. We then
filter editorRanges to include those where the filenames on file and
r.file match, excluding _test.go files