### PR TITLE
Check for atom-ide in package manager, fixes #682

### DIFF
--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -21,7 +21,11 @@ const bundledPackages = new Map([
   ['hyperclick', 'It enables alt-click for go to definition, and shift-alt-click to return to the prior location.'],
   ['go-debug', 'It allows you to interactively debug your go program and tests using delve.'],
   ['go-signature-statusbar', 'It shows function signature information in the status bar.'],
-  ['linter', 'It runs linters and displays lint results. Alternatively, you can use Facebook\'s Nuclide package instead of the linter package.']
+  ['linter', 'It runs linters and displays lint results. Alternatively, you can use atom-ide-ui.']
+])
+
+const bundledAlt = new Map([
+  ['linter', 'atom-ide-ui']
 ])
 
 const goTools = new Map([
@@ -102,9 +106,17 @@ class PackageManager {
         continue
       }
 
+      const altPkg = bundledAlt.get(pkg)
+      if (altPkg) {
+        const ap = atom.packages.getLoadedPackage(altPkg)
+        if (ap) {
+          continue
+        }
+      }
+
       let disabled = false
       for (const d of atom.config.get('go-plus.disabledBundledPackages')) {
-        if (d && d.trim() === pkg) {
+        if (d && [pkg, altPkg].includes(d.trim())) {
           disabled = true
           break
         }

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -21,11 +21,11 @@ const bundledPackages = new Map([
   ['hyperclick', 'It enables alt-click for go to definition, and shift-alt-click to return to the prior location.'],
   ['go-debug', 'It allows you to interactively debug your go program and tests using delve.'],
   ['go-signature-statusbar', 'It shows function signature information in the status bar.'],
-  ['linter', 'It runs linters and displays lint results. Alternatively, you can use atom-ide-ui.']
+  ['atom-ide-ui', 'It provides language ide features.']
 ])
 
-const bundledAlt = new Map([
-  ['linter', 'atom-ide-ui']
+const altPackages = new Map([
+  ['atom-ide-ui', ['linter', 'linter has been deprecated. linter can be used instead of atom-ide-ui for now, but with less features.']]
 ])
 
 const goTools = new Map([
@@ -100,19 +100,14 @@ class PackageManager {
 
   installBundledPackages () {
     let packages = new Map()
+    let warnings = new Map()
     for (const [pkg, detail] of bundledPackages) {
       const p = atom.packages.getLoadedPackage(pkg)
       if (p) {
         continue
       }
 
-      const altPkg = bundledAlt.get(pkg)
-      if (altPkg) {
-        const ap = atom.packages.getLoadedPackage(altPkg)
-        if (ap) {
-          continue
-        }
-      }
+      const [altPkg, warningMsg] = altPackages.get(pkg) || []
 
       let disabled = false
       for (const d of atom.config.get('go-plus.disabledBundledPackages')) {
@@ -125,7 +120,40 @@ class PackageManager {
         continue
       }
 
+      if (altPkg) {
+        const ap = atom.packages.getLoadedPackage(altPkg)
+        if (ap) {
+          if (warningMsg) {
+            warnings.set(altPkg, warningMsg)
+          }
+          continue
+        }
+      }
+
       packages.set(pkg, detail)
+    }
+
+    for (const [pkg, detail] of warnings) {
+      const notification = atom.notifications.addWarning('go-plus', {
+        dismissable: true,
+        detail: detail,
+        buttons: [{
+          text: 'OK',
+          onDidClick: () => {
+            notification.dismiss()
+          }
+        }, {
+          text: 'Don\'t Remind Me',
+          onDidClick: () => {
+            notification.dismiss()
+            const disabledBundledPackages = atom.config.get('go-plus.disabledBundledPackages')
+            if (!disabledBundledPackages.includes('pkg')) {
+              disabledBundledPackages.push(pkg)
+              atom.config.set('go-plus.disabledBundledPackages', disabledBundledPackages)
+            }
+          }
+        }]
+      })
     }
 
     if (!packages.size) {


### PR DESCRIPTION
Fixes #682. Added a bundledAlt map to check for alternative packages. Also changed verbiage of linter message since atom-ide-ui is maintained by Atom now.