### PR TITLE
Ll builder no go files

### DIFF
--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -151,8 +151,15 @@ class Builder {
     if (stdout && stdout.trim() !== '') {
       console.log('go ' + command + ': (stdout) ' + stdout)
     }
-    const stderr = r.stderr instanceof Buffer ? r.stderr.toString() : r.stderr
-    return { output: stderr.trim(), linterName: 'build', exitcode: r.exitcode }
+    let stderr = (r.stderr instanceof Buffer ? r.stderr.toString() : r.stderr).trim()
+    let exitcode = r.exitcode
+    if (stderr.indexOf('no non-test Go files in') >= 0) {
+      // pkgs may only contain go test files (e.g. integration tests)
+      // ignore this error because the test builder reports the errors then.
+      stderr = ''
+      exitcode = 0
+    }
+    return { output: stderr, linterName: 'build', exitcode }
   }
 
   devNull (): string {

--- a/lib/output-panel.js
+++ b/lib/output-panel.js
@@ -9,7 +9,7 @@ import EtchComponent from './etch-component'
 import AnsiStyle from './ansi'
 import { openFile, parseGoPosition, projectPath } from './utils'
 
-const locationRegex = /([\w-/.\\:]*.go:\d+)/g
+const locationRegex = /([\w-/.\\:]*.go:\d+(:\d+)?)/g
 
 export default class OutputPanel extends EtchComponent {
   scrollHeight: number


### PR DESCRIPTION
Ignore the error about `no non-test Go files` when building a package.

Also use the column in file links in the output panel.

Fixes #732