### PR TITLE
add config options for addditional build/test args

### DIFF
--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -1,10 +1,11 @@
 // @flow
 
-import {CompositeDisposable, Range} from 'atom'
+import argparser from 'yargs-parser/lib/tokenize-arg-string'
 import fs from 'fs-extra'
+import os from 'os'
 import path from 'path'
 import temp from 'temp'
-import os from 'os'
+import {CompositeDisposable, Range} from 'atom'
 import {isValidEditor} from './../utils'
 import {getgopath} from '../config/environment'
 
@@ -152,6 +153,12 @@ class Builder {
       buildArgs.push('-o')
       buildArgs.push(this.devNull())
     }
+    const additionalArgs = atom.config.get('go-plus.config.additionalBuildArgs')
+    if (additionalArgs && additionalArgs.length) {
+      const parsed = argparser(additionalArgs)
+      buildArgs.push(...parsed)
+    }
+
     buildArgs.push('.')
     this.output.update({
       output: 'Running go ' + buildArgs.join(' '),
@@ -177,8 +184,29 @@ class Builder {
     return process.platform === 'win32' ? 'NUL' : '/dev/null'
   }
 
+  testCompileArgs (additionalArgs: string = ''): Array<string> {
+    const result = ['test']
+    // use additional build args even when we compile the tests
+    if (additionalArgs && additionalArgs.length) {
+      const parsed = argparser(additionalArgs)
+      for (let i = 0; i < parsed.length; i++) {
+        if (parsed[i] === '-o') {
+          // we'll take care of this one, skip over the -o flag
+          i++
+          continue
+        } else if (parsed[i] === '-c' || parsed[i] === '-i') {
+          continue
+        } else {
+          result.push(parsed[i])
+        }
+      }
+    }
+    result.push('-c', '-i', '-o', this.devNull(), '.')
+    return result
+  }
+
   async lintTest (cmd: string, options: ExecutorOptions) {
-    const testArgs = ['test', '-c', '-i', '-o', this.devNull(), '.']
+    const testArgs = this.testCompileArgs(atom.config.get('go-plus.config.additionalBuildArgs'))
 
     this.output.update({
       output: 'Compiling tests:' + os.EOL + '$ go ' + testArgs.join(' '),

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -1,12 +1,13 @@
 // @flow
 
-import {CompositeDisposable} from 'atom'
 import _ from 'lodash'
 import fs from 'fs-extra'
 import os from 'os'
-import parser from './gocover-parser'
 import path from 'path'
 import temp from 'temp'
+import argparser from 'yargs-parser/lib/tokenize-arg-string'
+import {CompositeDisposable} from 'atom'
+import parser from './gocover-parser'
 import {getEditor, isValidEditor} from '../utils'
 
 import type {GoConfig} from './../config/service'
@@ -211,6 +212,45 @@ class Tester {
     this.coverageFile = path.join(this.tempDir, 'coverage.out')
   }
 
+  buildGoTestArgs (timeoutMillis: number = 60000): Array<string> {
+    const args = ['test', '-coverprofile=' + this.coverageFile]
+    const configFlags = atom.config.get('go-plus.config.additionalTestArgs')
+
+    let shortFlag = false
+    let verboseFlag = false
+    let userSuppliedTimout = false
+
+    if (configFlags && configFlags.length) {
+      const arr = argparser(configFlags)
+
+      for (const arg of arr) {
+        args.push(arg)
+        if (arg.startsWith('-timeout')) {
+          userSuppliedTimout = true
+        }
+        if (arg === '-short') {
+          shortFlag = true
+        }
+        if (arg === '-v') {
+          verboseFlag = true
+        }
+      }
+    }
+
+    if (!userSuppliedTimout) {
+      args.push('-timeout=' + timeoutMillis + 'ms')
+    }
+
+    if (!shortFlag && atom.config.get('go-plus.test.runTestsWithShortFlag')) {
+      args.push('-short')
+    }
+    if (!verboseFlag && atom.config.get('go-plus.test.runTestsWithVerboseFlag')) {
+      args.push('-v')
+    }
+
+    return args
+  }
+
   async runTests (editor: any = getEditor()): Promise<void> {
     if (!isValidEditor(editor)) {
       throw new Error('invalid editor')
@@ -244,16 +284,7 @@ class Tester {
     const timeout = atom.config.get('go-plus.test.timeout') || 60000
     executorOptions.timeout = timeout
 
-    const args = ['test', '-timeout=' + executorOptions.timeout + 'ms']
-    if (runTestsWithCoverage) {
-      args.push('-coverprofile=' + this.coverageFile)
-    }
-    if (atom.config.get('go-plus.test.runTestsWithShortFlag')) {
-      args.push('-short')
-    }
-    if (atom.config.get('go-plus.test.runTestsWithVerboseFlag')) {
-      args.push('-v')
-    }
+    const args = this.buildGoTestArgs(executorOptions.timeout)
     if (this.output) {
       this.output.update({
         output: 'Running go ' + args.join(' ') + ' with a ' + timeout + 'ms timeout',

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -212,8 +212,11 @@ class Tester {
     this.coverageFile = path.join(this.tempDir, 'coverage.out')
   }
 
-  buildGoTestArgs (timeoutMillis: number = 60000): Array<string> {
-    const args = ['test', '-coverprofile=' + this.coverageFile]
+  buildGoTestArgs (timeoutMillis: number = 60000, coverage: bool = false): Array<string> {
+    const args = ['test']
+    if (coverage) {
+      args.push('-coverprofile=' + this.coverageFile)
+    }
     const configFlags = atom.config.get('go-plus.config.additionalTestArgs')
 
     let shortFlag = false
@@ -284,7 +287,7 @@ class Tester {
     const timeout = atom.config.get('go-plus.test.timeout') || 60000
     executorOptions.timeout = timeout
 
-    const args = this.buildGoTestArgs(executorOptions.timeout)
+    const args = this.buildGoTestArgs(executorOptions.timeout, runTestsWithCoverage)
     if (this.output) {
       this.output.update({
         output: 'Running go ' + args.join(' ') + ' with a ' + timeout + 'ms timeout',

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "lodash": "^4.17.4",
     "resize-observer-polyfill": "^1.5.0",
     "semver": "^5.4.1",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "yargs-parser": "^8.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",
@@ -200,6 +201,20 @@
           "type": "boolean",
           "default": true,
           "order": 2
+        },
+        "additionalBuildArgs": {
+          "title": "Additional build/install args",
+          "description": "Arguments to pass to `go build` and `go install` commands.",
+          "type": "string",
+          "default": "",
+          "order": 3
+        },
+        "additionalTestArgs": {
+          "title": "Additional test args",
+          "description": "Arguments to pass to `go test` commands.",
+          "type": "string",
+          "default": "",
+          "order": 4
         }
       }
     },

--- a/spec/build/builder-spec.js
+++ b/spec/build/builder-spec.js
@@ -32,6 +32,55 @@ describe('builder', () => {
     lifecycle.teardown()
   })
 
+  describe('test executable', () => {
+    it('provides a standard set of flags for compilation', () => {
+      ['', '   '].forEach(setting => {
+        const args = builder.testCompileArgs(setting)
+        expect(args[0]).toEqual('test')
+        expect(args).toContain('-c')
+        expect(args).toContain('-i')
+        expect(args).toContain('-o')
+        expect(args.includes('/dev/null') || args.includes('NUL')).toEqual(true)
+        expect(args).toContain('.')
+      })
+    })
+
+    it('includes additional args', () => {
+      const args = builder.testCompileArgs('-foo -bar 5')
+      expect(args[0]).toEqual('test')
+      expect(args).toContain('-c')
+      expect(args).toContain('-i')
+      expect(args).toContain('-o')
+      expect(args.includes('/dev/null') || args.includes('NUL')).toEqual(true)
+      expect(args).toContain('.')
+      expect(args).toContain('-foo')
+      expect(args).toContain('-bar')
+      expect(args).toContain('5')
+    })
+
+    it('puts additional args before the package path', () => {
+      const args = builder.testCompileArgs('-foo')
+      const dot = args.indexOf('.')
+      const foo = args.indexOf('-foo')
+      expect(dot).not.toEqual(-1)
+      expect(foo).not.toEqual(-1)
+      expect(foo).toBeLessThan(dot)
+    })
+
+    it('does not duplicate args', () => {
+      const args = builder.testCompileArgs('-c -i')
+      expect(args.filter(x => x === '-c').length).toEqual(1)
+      expect(args.filter(x => x === '-i').length).toEqual(1)
+    })
+
+    it('does not allow overriding the output file', () => {
+      const args = builder.testCompileArgs('-o /root/dont_write_here')
+      const i = args.indexOf('-o')
+      expect(i).not.toEqual(-1)
+      expect(args[i+1]).not.toEqual('/root/dont_write_here')
+    })
+  })
+
   describe('build command', () => {
     it('runs go build for code outside gopath', () => {
       [{

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -76,7 +76,7 @@ describe('tester', () => {
     })
 
     it('uses the specified timeout', () => {
-      const args = tester.buildGoTestArgs(10000)
+      const args = tester.buildGoTestArgs(10000, false)
       let foundTimeout = false
       for (const arg of args) {
         if (arg.startsWith('-timeout')) {
@@ -88,7 +88,7 @@ describe('tester', () => {
     })
 
     it('invokes the go test command with a coverprofile', () => {
-      const args = tester.buildGoTestArgs(10000)
+      const args = tester.buildGoTestArgs(10000, true)
       expect(args[0]).toBe('test')
       expect(args[1].startsWith('-coverprofile=')).toBe(true)
     })
@@ -96,7 +96,7 @@ describe('tester', () => {
     describe('when specifying custom args', () => {
       it('prefers timeout from the custom args (if specified)', () => {
         atom.config.set('go-plus.config.additionalTestArgs', '-timeout=4000ms')
-        const args = tester.buildGoTestArgs(8000)
+        const args = tester.buildGoTestArgs(8000, false)
         let foundTimeout = false
         for (const arg of args) {
           if (arg.startsWith('-timeout')) {

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -121,10 +121,12 @@ describe('tester', () => {
       })
 
       it('handles args with spaces', () => {
-        atom.config.set('go-plus.config.additionalTestArgs', '-myarg="hello world"')
+        atom.config.set('go-plus.config.additionalTestArgs', '-myarg="hello world"  -arg2   3')
         const args = tester.buildGoTestArgs()
-        expect(args.length >= 3).toBeTruthy()
-        expect(args[2]).toBe('-myarg=hello world')
+        expect(args.length).toBeGreaterThan(3)
+        expect(args[1]).toEqual('-myarg=hello world')
+        expect(args[2]).toEqual('-arg2')
+        expect(args[3]).toEqual('3')
       })
     })
   })

--- a/spec/test/tester-spec.js
+++ b/spec/test/tester-spec.js
@@ -65,6 +65,70 @@ describe('tester', () => {
     lifecycle.teardown()
   })
 
+  describe('go test args', () => {
+    beforeEach(() => {
+      atom.config.unset('go-plus.config.additionalTestArgs')
+    })
+
+    afterEach(() => {
+      atom.config.set('go-plus.test.runTestsWithShortFlag', true)
+      atom.config.set('go-plus.test.runTestsWithVerboseFlag', false)
+    })
+
+    it('uses the specified timeout', () => {
+      const args = tester.buildGoTestArgs(10000)
+      let foundTimeout = false
+      for (const arg of args) {
+        if (arg.startsWith('-timeout')) {
+          foundTimeout = true
+          expect(arg).toBe('-timeout=10000ms')
+        }
+      }
+      expect(foundTimeout).toBe(true)
+    })
+
+    it('invokes the go test command with a coverprofile', () => {
+      const args = tester.buildGoTestArgs(10000)
+      expect(args[0]).toBe('test')
+      expect(args[1].startsWith('-coverprofile=')).toBe(true)
+    })
+
+    describe('when specifying custom args', () => {
+      it('prefers timeout from the custom args (if specified)', () => {
+        atom.config.set('go-plus.config.additionalTestArgs', '-timeout=4000ms')
+        const args = tester.buildGoTestArgs(8000)
+        let foundTimeout = false
+        for (const arg of args) {
+          if (arg.startsWith('-timeout')) {
+            foundTimeout = true
+            expect(arg).toBe('-timeout=4000ms')
+          }
+        }
+        expect(foundTimeout).toBe(true)
+      })
+
+      it('does not duplicate the -short or -verbose flags', () => {
+        atom.config.set('go-plus.test.runTestsWithShortFlag', true)
+        atom.config.set('go-plus.test.runTestsWithVerboseFlag', true)
+        atom.config.set('go-plus.config.additionalTestArgs', '-short -verbose')
+
+        const args = tester.buildGoTestArgs()
+        const shortFlags = args.filter((a) => a === '-short').length
+        const verboseFlags = args.filter((a) => a === '-v').length
+
+        expect(shortFlags).toBe(1)
+        expect(verboseFlags).toBe(1)
+      })
+
+      it('handles args with spaces', () => {
+        atom.config.set('go-plus.config.additionalTestArgs', '-myarg="hello world"')
+        const args = tester.buildGoTestArgs()
+        expect(args.length >= 3).toBeTruthy()
+        expect(args[2]).toBe('-myarg=hello world')
+      })
+    })
+  })
+
   describe('when run tests on save is enabled, but compile on save is disabled', () => {
     it('runs tests', () => {
       let buffer


### PR DESCRIPTION
Introduce `go-plus.config.additional{Build|Test}Args` config properties that allow users to alter the flags that are passed to:

build args:
- go build / go install
- go test -c

test args:
- go test -coverprofile

This can be used to define build tags, for example.

- Fixes #282
- Fixes #308
- Fixes #551
- Fixes #573
- Fixes #690
- Closes #565