### PR TITLE
Better compatibility with mdempsky/gocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ The following commands are run for the directory of the current file:
 
 ### Why Are You Running `go install` Instead Of `go build`?
 
-`gocode` (and a few other tools, like `gotype`) work on `.a` files (i.e. the package object archive), and the way to keep these up to date is to run `go install` periodically. This ensures your autocomplete suggestions are kept up to date without having to resort to `gocode set autobuild true` :tada:.
-
-### But What About `gb`?
-
-We are open to suggestions for detecting a package which is built with gb; please feel free to submit a pull request that detects a gb package without any explicit configuration and runs it.
+`gocode` (and a few other tools, like `gotype`) work on `.a` files (i.e. the package object archive), and the way to keep these up to date is to run `go install` periodically. This ensures your autocomplete suggestions are kept up to date.
 
 ## Platforms
 

--- a/lib/autocomplete/gocodeprovider.js
+++ b/lib/autocomplete/gocodeprovider.js
@@ -61,7 +61,6 @@ class GocodeProvider implements AutocompleteProvider {
     this.currentColumn = -1
 
     this.proposeBuiltins = true
-    this.unimportedPackages = true
     this.selector = '.source.go, go source_file'
     this.inclusionPriority = 1
     this.excludeLowerPriority = atom.config.get(
@@ -104,15 +103,13 @@ class GocodeProvider implements AutocompleteProvider {
     this.subscriptions.add(
       atom.config.observe('go-plus.autocomplete.proposeBuiltins', value => {
         this.proposeBuiltins = value
-        this.toggleGocodeConfig()
       })
     )
-    this.subscriptions.add(
-      atom.config.observe('go-plus.autocomplete.unimportedPackages', value => {
-        this.unimportedPackages = value
-        this.toggleGocodeConfig()
-      })
-    )
+    // this.subscriptions.add(
+    //   atom.config.observe('go-plus.autocomplete.unimportedPackages', value => {
+    //     this.unimportedPackages = value
+    //   })
+    // )
 
     this.allPkgs = allPackages(this.goconfig)
   }
@@ -124,58 +121,6 @@ class GocodeProvider implements AutocompleteProvider {
     this.subscriptions = null
     this.subscribers = []
     this.resetCache()
-  }
-
-  toggleGocodeConfig () {
-    if (this.goconfig) {
-      this.goconfig.locator
-        .findTool('gocode')
-        .then(cmd => {
-          if (!cmd) {
-            return
-          }
-          const gocode = cmd
-          const opt = this.goconfig.executor.getOptions('file')
-          this.goconfig.executor
-            .exec(
-              gocode,
-              [
-                'set',
-                'unimported-packages',
-                this.unimportedPackages.toString()
-              ],
-              opt
-            )
-            .then(r => {
-              const stderr =
-                r.stderr instanceof Buffer ? r.stderr.toString() : r.stderr
-              if (stderr && stderr.trim() !== '') {
-                console.log('autocomplete-go: (stderr) ' + stderr)
-              }
-            })
-            .then(() => {
-              if (!this.goconfig) {
-                return
-              }
-              return this.goconfig.executor
-                .exec(
-                  gocode,
-                  ['set', 'propose-builtins', this.proposeBuiltins.toString()],
-                  opt
-                )
-                .then(r => {
-                  const stderr =
-                    r.stderr instanceof Buffer ? r.stderr.toString() : r.stderr
-                  if (stderr && stderr.trim() !== '') {
-                    console.log('autocomplete-go: (stderr) ' + stderr)
-                  }
-                })
-            })
-        })
-        .catch(e => {
-          console.log(e)
-        })
-    }
   }
 
   filterSelectors () {
@@ -325,6 +270,10 @@ class GocodeProvider implements AutocompleteProvider {
         }
         const file = buffer.getPath()
         const args = ['-f=json', 'autocomplete', file, offset.toString()]
+        if (this.proposeBuiltins) {
+          args.unshift('-builtin')
+        }
+
         const execOptions = this.goconfig.executor.getOptions('file', editor)
         execOptions.input = text
 

--- a/package.json
+++ b/package.json
@@ -300,13 +300,6 @@
           "type": "boolean",
           "default": true,
           "order": 5
-        },
-        "unimportedPackages": {
-          "title": "Unimported Packages",
-          "description": "Provide suggestions for unimported packages. Default: true.",
-          "type": "boolean",
-          "default": true,
-          "order": 6
         }
       }
     },


### PR DESCRIPTION
Remove calls to `gocode set`

mdempsky/gocode doesn't support this operation.
You can now request builtins by using -builtin.
There is not currently an option to enable completions for unimported packages.