### PR TITLE
Always use formatter result when exit code is 0

### DIFF
--- a/lib/format/formatter.js
+++ b/lib/format/formatter.js
@@ -164,7 +164,6 @@ class Formatter {
       this.updateFormatterCache()
       return
     }
-
     const options = this.goconfig.executor.getOptions('project')
     options.input = editor.getText()
     const args = ['-e']
@@ -179,7 +178,6 @@ class Formatter {
     const stderr = r.stderr instanceof Buffer ? r.stderr.toString() : r.stderr
     if (stderr && stderr.trim() !== '') {
       console.log('gofmt: (stderr) ' + stderr)
-      return
     }
     if (r.exitcode === 0) {
       editor.getBuffer().setTextViaDiff(r.stdout)

--- a/spec/format/formatter-spec.js
+++ b/spec/format/formatter-spec.js
@@ -116,6 +116,28 @@ describe('formatter', () => {
             expect(editor.getText()).toBe(formattedText)
           })
         })
+
+        describe('when gofmt writes to stderr, but otherwise succeeds', () => {
+          it('still updates the buffer', () => {
+            runs(() => {
+              spyOn(formatter.goconfig.executor, 'execSync').andReturn({
+                exitcode: 0,
+                stderr: 'warning',
+                stdout: formattedText
+              })
+            })
+
+            waitsForPromise(() => {
+              return setTextAndSave(editor, unformattedText)
+            })
+
+            runs(() => {
+              const target = atom.views.getView(editor)
+              atom.commands.dispatch(target, 'golang:gofmt')
+              expect(editor.getText()).toBe(formattedText)
+            })
+          })
+        })
       })
     })
 


### PR DESCRIPTION
We previously aborted the format operation if there was output on stderr.

Fixes #600