### PR TITLE
Use coverageFile specified by -coverprofile, if given

### DIFF
--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -276,11 +276,18 @@ class Tester {
   }
 
   createCoverageFile() {
-    this.removeTempDir()
-    if (!this.tempDir) {
-      this.tempDir = fs.realpathSync(temp.mkdirSync())
+    const additionalTestArgs = atom.config.get('go-plus.config.additionalTestArgs')
+    const res = additionalTestArgs.match(/-coverprofile=([A-Za-z0-9/\._-]+)/);
+
+    if (res != null) {
+      this.coverageFile = res[1]
+    } else {
+      this.removeTempDir()
+      if (!this.tempDir) {
+        this.tempDir = fs.realpathSync(temp.mkdirSync())
+      }
+      this.coverageFile = path.join(this.tempDir, 'coverage.out')
     }
-    this.coverageFile = path.join(this.tempDir, 'coverage.out')
   }
 
   buildGoTestArgs(
@@ -288,14 +295,12 @@ class Tester {
     coverage: boolean = false
   ): Array<string> {
     const args = ['test']
-    if (coverage) {
-      args.push('-coverprofile=' + this.coverageFile)
-    }
     const configFlags = atom.config.get('go-plus.config.additionalTestArgs')
 
     let shortFlag = false
     let verboseFlag = false
     let userSuppliedTimeout = false
+    let customCoverage = false
 
     if (configFlags && configFlags.length) {
       const arr = argparser(configFlags)
@@ -311,7 +316,14 @@ class Tester {
         if (arg === '-v') {
           verboseFlag = true
         }
+        if (arg.startsWith('-coverprofile')) {
+          customCoverage = true
+        }
       }
+    }
+
+    if (coverage && !customCoverage) {
+      args.push('-coverprofile=' + this.coverageFile)
     }
 
     if (!userSuppliedTimeout) {

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -277,7 +277,7 @@ class Tester {
 
   createCoverageFile() {
     const additionalTestArgs = atom.config.get('go-plus.config.additionalTestArgs')
-    const res = additionalTestArgs.match(/-coverprofile=([^ ]+)/);
+    const res = additionalTestArgs.match(/-coverprofile=([^\s]+)/);
 
     if (res != null) {
       this.coverageFile = res[1]

--- a/lib/test/tester.js
+++ b/lib/test/tester.js
@@ -277,7 +277,7 @@ class Tester {
 
   createCoverageFile() {
     const additionalTestArgs = atom.config.get('go-plus.config.additionalTestArgs')
-    const res = additionalTestArgs.match(/-coverprofile=([A-Za-z0-9/\._-]+)/);
+    const res = additionalTestArgs.match(/-coverprofile=([^ ]+)/);
 
     if (res != null) {
       this.coverageFile = res[1]


### PR DESCRIPTION
Fixes an issue related to https://github.com/joefitzgerald/go-plus/issues/832:

If a -coverprofile is specified in "Additional test args", then use the given filepath.
Possible improvement: Add a random directory between given dir and file. A static coverage file _may_ cause issues, such as race conditions.

I am not an experienced JS developer, so treat this as a Proof of Concept ;)
