### PR TITLE
support revive and golangci-lint linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package includes the following functionality:
   optionally run one of these tools on save of any `.go` file
 - Run `go install .` and `go test -c -o {tempdir} .` to verify your code compiles
   and to keep `gocode` suggestions up to date
-- Run a variety of linters (e.g. `golint`, `vet`, etc.) against your code using `gometalinter`
+- Run a variety of linters (e.g. `golint`, `vet`, etc.) against your code using [`gometalinter`](https://github.com/alecthomas/gometalinter), [`revive`](https://github.com/mgechev/revive) or [`golangci-lint`](https://github.com/golangci/golangci-lint)
 - Run tests, display test output, and display test coverage using `go test -coverprofile`
 - Display documentation for identifiers in source code using
   [`gogetdoc`](https://github.com/zmb3/gogetdoc)
@@ -59,6 +59,8 @@ go get -u golang.org/x/tools/cmd/gorename
 go get -u github.com/sqs/goreturns
 go get -u github.com/mdempsky/gocode
 go get -u github.com/alecthomas/gometalinter
+go get -u github.com/mgechev/revive
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 go get -u github.com/zmb3/gogetdoc
 go get -u github.com/zmb3/goaddimport
 go get -u github.com/rogpeppe/godef

--- a/lib/lint/linter.js
+++ b/lib/lint/linter.js
@@ -1,12 +1,12 @@
 // @flow
 
 import path from 'path'
-import { Range } from 'atom'
+import { Range, TextEditor } from 'atom'
 import { isValidEditor } from './../utils'
 
 import type { Disposable, Point } from 'atom'
 import type { GoConfig } from './../config/service'
-import type { ExecResult } from './../config/executor'
+import type { ExecutorOptions, ExecResult } from './../config/executor'
 
 export type LinterV2Message = {
   name?: string,
@@ -50,7 +50,7 @@ export type LinterDelegate = {
   dispose(): void
 }
 
-class GometalinterLinter {
+class Linter {
   goconfig: GoConfig
   linter: () => LinterDelegate
   busySignal: () => ?BusySignalService
@@ -84,7 +84,7 @@ class GometalinterLinter {
     }
   }
 
-  lint(editor: any): Promise<void> {
+  lint(editor: TextEditor): Promise<void> {
     const bs = this.busySignal()
     const lintPromise = this.doLint(editor)
     return bs
@@ -92,7 +92,7 @@ class GometalinterLinter {
       : lintPromise
   }
 
-  async doLint(editor: any): Promise<void> {
+  async doLint(editor: TextEditor): Promise<void> {
     if (!isValidEditor(editor)) {
       return
     }
@@ -102,33 +102,18 @@ class GometalinterLinter {
       return
     }
     this.deleteMessages()
-    const configuredArgs = atom.config.get('go-plus.lint.args')
-    let args: Array<string>
-    if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
-      args = (configuredArgs: any)
-    } else {
-      args = [
-        '--vendor',
-        '--disable-all',
-        '--enable=vet',
-        '--enable=vetshadow',
-        '--enable=golint',
-        '--enable=ineffassign',
-        '--enable=goconst',
-        '--tests',
-        '--json',
-        '.'
-      ]
-    }
-    if (!args.includes('--json')) {
-      args.unshift('--json')
-    }
 
-    const options = this.goconfig.executor.getOptions('file')
-    const cmd = await this.goconfig.locator.findTool('gometalinter')
+    const tool: string = (atom.config.get('go-plus.lint.tool'): any)
+    const cmd = await this.goconfig.locator.findTool(tool)
     if (!cmd) {
       return
     }
+
+    const options = this.goconfig.executor.getOptions('file')
+
+    let args = TOOLS[tool.toLowerCase()].prepareArgs()
+    args = replaceVariables(args, editor.getPath(), options)
+
     const r: ExecResult = await this.goconfig.executor.exec(cmd, args, options)
     if (!r) {
       return
@@ -136,77 +121,246 @@ class GometalinterLinter {
     const stderr = r.stderr instanceof Buffer ? r.stderr.toString() : r.stderr
     const stdout = r.stdout instanceof Buffer ? r.stdout.toString() : r.stdout
     if (stderr && stderr.trim() !== '') {
-      console.log('gometalinter-linter: (stderr) ' + stderr) // eslint-disable-line no-console
+      console.log(`${tool}-linter: (stderr) ` + stderr) // eslint-disable-line no-console
     }
     let messages: Array<LinterV2Message> = []
     if (stdout && stdout.trim() !== '') {
-      messages = this.mapMessages(stdout, editor, options.cwd || '')
+      messages = TOOLS[tool.toLowerCase()].mapMessages(
+        stdout,
+        editor,
+        options.cwd || ''
+      )
+
+      messages.sort((a, b) => {
+        if (a.location.file === b.location.file) {
+          return a.location.position.compare(b.location.position)
+        } else {
+          return a.location.file.localeCompare(b.location.file)
+        }
+      })
     }
     this.setMessages(messages)
   }
+}
+export { Linter }
 
-  mapMessages(data: string, editor: any, cwd: string): Array<LinterV2Message> {
-    let messages = []
-    try {
-      messages = JSON.parse(data)
-    } catch (e) {
-      console.log(e) // eslint-disable-line no-console
-    }
-
-    if (!messages || messages.length < 1) {
-      return []
-    }
-    messages.sort((a, b) => {
-      if (!a && !b) {
-        return 0
+const regexVariable = /\${(.*?)}/g
+function replaceVariables(
+  args: string[],
+  file: ?string,
+  options: ExecutorOptions
+): string[] {
+  const workspaceFile = file && atom.project.relativizePath(file)
+  const variables = {
+    env: (options.env: any),
+    cwd: options.cwd,
+    file,
+    fileBasename: file && path.basename(file),
+    fileDirname: file && path.dirname(file),
+    relativeFile: workspaceFile && workspaceFile[1],
+    workspaceRoot: workspaceFile && workspaceFile[0]
+  }
+  return args.map(arg => {
+    return arg.replace(regexVariable, (group, name) => {
+      if (name.startsWith('env.')) {
+        return variables.env[name.replace('env.', '')]
       }
-      if (!a && b) {
-        return -1
-      }
-      if (a && !b) {
-        return 1
-      }
-
-      if (!a.path && b.path) {
-        return -1
-      }
-      if (a.path && !b.path) {
-        return 1
-      }
-      if (a.path === b.path) {
-        if (a.line - b.line === 0) {
-          return a.row - b.row
-        }
-        return a.line - b.line
-      } else {
-        return a.path.localeCompare(b.path)
-      }
+      return variables[name]
     })
+  })
+}
 
-    const results: Array<LinterV2Message> = []
+type Tool = {
+  prepareArgs(): string[],
+  mapMessages(
+    stdout: string,
+    editor: TextEditor,
+    cwd: string
+  ): LinterV2Message[]
+}
 
-    for (const message of messages) {
-      let range
-      if (message.col && message.col >= 0) {
-        range = new Range(
-          [message.line - 1, message.col - 1],
-          [message.line - 1, 1000]
-        )
+const TOOLS: { [string]: Tool } = {
+  gometalinter: {
+    prepareArgs(): string[] {
+      const configuredArgs = atom.config.get('go-plus.lint.args')
+      let args: string[]
+      if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
+        args = (configuredArgs: any)
       } else {
-        range = new Range([message.line - 1, 0], [message.line - 1, 1000])
+        args = [
+          '--vendor',
+          '--disable-all',
+          '--enable=vet',
+          '--enable=vetshadow',
+          '--enable=golint',
+          '--enable=ineffassign',
+          '--enable=goconst',
+          '--tests',
+          '--json',
+          '.'
+        ]
       }
-      results.push({
-        linterName: message.linter,
-        severity: message.severity.toLowerCase(),
-        location: {
-          file: path.join(cwd, message.path),
-          position: range
-        },
-        excerpt: message.message + ' (' + message.linter + ')'
+      if (!args.includes('--json')) {
+        args.unshift('--json')
+      }
+      return args
+    },
+    mapMessages(
+      stdout: string,
+      editor: TextEditor,
+      cwd: string
+    ): Array<LinterV2Message> {
+      let messages = []
+      try {
+        messages = JSON.parse(stdout)
+      } catch (e) {
+        console.log(e) // eslint-disable-line no-console
+      }
+      if (!messages || messages.length < 1) {
+        return []
+      }
+
+      const results: Array<LinterV2Message> = []
+
+      for (const message of messages) {
+        let range
+        if (message.col && message.col >= 0) {
+          range = new Range(
+            [message.line - 1, message.col - 1],
+            [message.line - 1, 1000]
+          )
+        } else {
+          range = new Range([message.line - 1, 0], [message.line - 1, 1000])
+        }
+        results.push({
+          linterName: message.linter,
+          severity: message.severity.toLowerCase(),
+          location: {
+            file: path.join(cwd, message.path),
+            position: range
+          },
+          excerpt: message.message + ' (' + message.linter + ')'
+        })
+      }
+
+      return results
+    }
+  },
+  revive: {
+    prepareArgs(): string[] {
+      const configuredArgs = atom.config.get('go-plus.lint.args')
+      let args: string[] = ['--formatter=json']
+      if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
+        for (let i = 0; i < configuredArgs.length; i++) {
+          const arg: string = (configuredArgs[i]: any)
+          if (arg === '-formatter') {
+            i++ // skip this and the following value
+            continue
+          }
+          if (arg.startsWith('--formatter=')) {
+            continue
+          }
+          args.push(arg)
+        }
+      }
+      return args
+    },
+    mapMessages(
+      stdout: string,
+      editor: TextEditor,
+      cwd: string
+    ): Array<LinterV2Message> {
+      let messages = []
+      try {
+        messages = JSON.parse(stdout)
+      } catch (e) {
+        console.log(e) // eslint-disable-line no-console
+      }
+
+      if (!messages || messages.length < 1) {
+        return []
+      }
+
+      return messages.map(m => {
+        const position = new Range(
+          [m.Position.Start.Line - 1, m.Position.Start.Column - 1],
+          [m.Position.End.Line - 1, m.Position.End.Column - 1]
+        )
+
+        const message: LinterV2Message = {
+          location: {
+            file: path.join(cwd, m.Position.Start.Filename),
+            position
+          },
+          url: `https://revive.run/r#${m.RuleName}`,
+          excerpt: `${m.Failure} (${m.RuleName})`,
+          severity: m.Severity.toLowerCase(),
+          linterName: 'revive'
+        }
+
+        if (m.ReplacementLine) {
+          message.solutions = [
+            {
+              position: new Range(
+                [position.start.row, 0],
+                [position.start.row, 1000]
+              ),
+              replaceWith: m.ReplacementLine
+            }
+          ]
+        }
+
+        return message
       })
     }
+  },
+  'golangci-lint': {
+    prepareArgs(): string[] {
+      const configuredArgs = atom.config.get('go-plus.lint.args')
+      let args: string[] = ['run', '--out-format=json']
+      if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
+        for (let i = 0; i < configuredArgs.length; i++) {
+          const arg: string = (configuredArgs[i]: any)
+          if (arg.startsWith('--out-format')) {
+            continue
+          }
+          args.push(arg)
+        }
+      }
+      return args
+    },
+    mapMessages(
+      stdout: string,
+      editor: TextEditor,
+      cwd: string
+    ): Array<LinterV2Message> {
+      let parsed
+      try {
+        parsed = JSON.parse(stdout)
+      } catch (e) {
+        console.log(e) // eslint-disable-line no-console
+      }
 
-    return results
+      const issues = (parsed && parsed.Issues) || []
+      if (issues.length < 1) {
+        return []
+      }
+
+      return issues.map(i => {
+        const position = new Range(
+          [i.Pos.Line - 1, i.Pos.Column - 1],
+          [i.Pos.Line - 1, 1000]
+        )
+        return {
+          location: {
+            file: path.join(cwd, i.Pos.Filename),
+            position
+          },
+          excerpt: i.Text,
+          severity: 'warning',
+          linterName: i.FromLinter
+        }
+      })
+    }
   }
 }
-export { GometalinterLinter }

--- a/lib/lint/linter.js
+++ b/lib/lint/linter.js
@@ -1,5 +1,6 @@
 // @flow
 
+import argparser from 'yargs-parser/lib/tokenize-arg-string'
 import path from 'path'
 import { Range, TextEditor } from 'atom'
 import { isValidEditor } from './../utils'
@@ -111,7 +112,14 @@ class Linter {
 
     const options = this.goconfig.executor.getOptions('file')
 
-    let args = TOOLS[tool.toLowerCase()].prepareArgs()
+    let configuredArgs: string | string[] = (atom.config.get(
+      'go-plus.lint.args'
+    ): any)
+    if (typeof configuredArgs === 'string') {
+      configuredArgs = configuredArgs ? argparser(configuredArgs) : []
+    }
+
+    let args = TOOLS[tool.toLowerCase()].prepareArgs(configuredArgs)
     args = replaceVariables(args, editor.getPath(), options)
 
     const r: ExecResult = await this.goconfig.executor.exec(cmd, args, options)
@@ -171,7 +179,7 @@ function replaceVariables(
 }
 
 type Tool = {
-  prepareArgs(): string[],
+  prepareArgs(configuredArgs: string[]): string[],
   mapMessages(
     stdout: string,
     editor: TextEditor,
@@ -181,12 +189,9 @@ type Tool = {
 
 const TOOLS: { [string]: Tool } = {
   gometalinter: {
-    prepareArgs(): string[] {
-      const configuredArgs = atom.config.get('go-plus.lint.args')
-      let args: string[]
-      if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
-        args = (configuredArgs: any)
-      } else {
+    prepareArgs(configuredArgs: string[]): string[] {
+      let args = [...configuredArgs]
+      if (!args.length) {
         args = [
           '--vendor',
           '--disable-all',
@@ -247,8 +252,7 @@ const TOOLS: { [string]: Tool } = {
     }
   },
   revive: {
-    prepareArgs(): string[] {
-      const configuredArgs = atom.config.get('go-plus.lint.args')
+    prepareArgs(configuredArgs: string[]): string[] {
       let args: string[] = ['--formatter=json']
       if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
         for (let i = 0; i < configuredArgs.length; i++) {
@@ -315,9 +319,8 @@ const TOOLS: { [string]: Tool } = {
     }
   },
   'golangci-lint': {
-    prepareArgs(): string[] {
-      const configuredArgs = atom.config.get('go-plus.lint.args')
-      let args: string[] = ['run', '--out-format=json']
+    prepareArgs(configuredArgs: string[]): string[] {
+      const args: string[] = ['run', '--out-format=json']
       if (Array.isArray(configuredArgs) && configuredArgs.length > 0) {
         for (let i = 0; i < configuredArgs.length; i++) {
           const arg: string = (configuredArgs[i]: any)

--- a/lib/main.js
+++ b/lib/main.js
@@ -78,7 +78,7 @@ export default {
     this.information = null
     this.implements = null
     this.importer = null
-    this.linter = null
+    this.golinter = null
     this.orchestrator = null
     this.outputManager = null
     this.panelManager = null
@@ -123,7 +123,7 @@ export default {
     )
     this.subscriptions.add(
       this.orchestrator.register('linter', (editor, path) => {
-        if (this.linter) this.linter.lint(editor, path)
+        if (this.golinter) this.golinter.lint(editor, path)
         return
       })
     )
@@ -322,21 +322,21 @@ export default {
   },
 
   loadLinter() {
-    if (this.linter) {
-      return this.linter
+    if (this.golinter) {
+      return this.golinter
     }
     const { Linter } = require('./lint/linter')
-    this.linter = new Linter(
+    this.golinter = new Linter(
       this.provideGoConfig(),
-      () => this.linterLinter,
+      () => this.linter,
       () => this.busySignal
     )
 
     if (this.subscriptions) {
-      this.subscriptions.add(this.linter)
+      this.subscriptions.add(this.golinter)
     }
 
-    return this.linter
+    return this.golinter
   },
 
   loadNavigator() {
@@ -426,8 +426,8 @@ export default {
   consumeLinter(registry: any) {
     this.buildLinter = registry({ name: 'go build' })
     this.subscriptions.add(this.buildLinter)
-    this.linterLinter = registry({ name: 'go linter' })
-    this.subscriptions.add(this.linterLinter)
+    this.linter = registry({ name: 'go linter' })
+    this.subscriptions.add(this.linter)
   },
 
   consumeDatatipService(service: any) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -97,7 +97,7 @@ export default {
     this.loadInformation()
     this.loadBuilder()
     this.loadTester()
-    this.loadGometalinter()
+    this.loadLinter()
     this.loadDoc()
     this.loadImplements()
     this.loadGorename()
@@ -321,14 +321,14 @@ export default {
     return this.builder
   },
 
-  loadGometalinter() {
+  loadLinter() {
     if (this.linter) {
       return this.linter
     }
-    const { GometalinterLinter } = require('./lint/linter')
-    this.linter = new GometalinterLinter(
+    const { Linter } = require('./lint/linter')
+    this.linter = new Linter(
       this.provideGoConfig(),
-      () => this.gometalinterLinter,
+      () => this.linterLinter,
       () => this.busySignal
     )
 
@@ -426,8 +426,8 @@ export default {
   consumeLinter(registry: any) {
     this.buildLinter = registry({ name: 'go build' })
     this.subscriptions.add(this.buildLinter)
-    this.gometalinterLinter = registry({ name: 'gometalinter' })
-    this.subscriptions.add(this.gometalinterLinter)
+    this.linterLinter = registry({ name: 'go linter' })
+    this.subscriptions.add(this.linterLinter)
   },
 
   consumeDatatipService(service: any) {

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -39,6 +39,8 @@ const goTools = new Map([
   ['goreturns', 'github.com/sqs/goreturns'],
   ['gocode', 'github.com/mdempsky/gocode'],
   ['gometalinter', 'github.com/alecthomas/gometalinter'],
+  ['revive', 'github.com/mgechev/revive'],
+  ['golangci-lint', 'github.com/golangci-lint/cmd/golangci-lint'],
   ['gogetdoc', 'github.com/zmb3/gogetdoc'],
   ['goaddimport', 'github.com/zmb3/goaddimport'],
   ['godef', 'github.com/rogpeppe/godef'],

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -40,7 +40,7 @@ const goTools = new Map([
   ['gocode', 'github.com/mdempsky/gocode'],
   ['gometalinter', 'github.com/alecthomas/gometalinter'],
   ['revive', 'github.com/mgechev/revive'],
-  ['golangci-lint', 'github.com/golangci-lint/cmd/golangci-lint'],
+  ['golangci-lint', 'github.com/golangci/golangci-lint/cmd/golangci-lint'],
   ['gogetdoc', 'github.com/zmb3/gogetdoc'],
   ['goaddimport', 'github.com/zmb3/goaddimport'],
   ['godef', 'github.com/rogpeppe/godef'],

--- a/package.json
+++ b/package.json
@@ -397,9 +397,21 @@
       "title": "Lint",
       "type": "object",
       "properties": {
+        "tool": {
+          "title": "Linter",
+          "description": "The linter that is used to lint your code",
+          "type": "string",
+          "default": "gometalinter",
+          "enum": [
+            "gometalinter",
+            "revive",
+            "golangci-lint"
+          ],
+          "order": 1
+        },
         "args": {
-          "title": "gometalinter Arguments",
-          "description": "Arguments to be passed when invoking `gometalinter`. Please ensure the `--json` argument is always included. Arguments are comma-separated.",
+          "title": "Linter Arguments",
+          "description": "Arguments to be passed when invoking the provided linter. Arguments are comma-separated.",
           "type": "array",
           "default": [
             "--vendor",
@@ -416,7 +428,7 @@
           "items": {
             "type": "string"
           },
-          "order": 1
+          "order": 2
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -411,23 +411,9 @@
         },
         "args": {
           "title": "Linter Arguments",
-          "description": "Arguments to be passed when invoking the provided linter. Arguments are comma-separated.",
-          "type": "array",
-          "default": [
-            "--vendor",
-            "--disable-all",
-            "--enable=vet",
-            "--enable=vetshadow",
-            "--enable=golint",
-            "--enable=ineffassign",
-            "--enable=goconst",
-            "--tests",
-            "--json",
-            "."
-          ],
-          "items": {
-            "type": "string"
-          },
+          "description": "Arguments to be passed when invoking the provided linter.",
+          "type": "any",
+          "default": "",
           "order": 2
         }
       }


### PR DESCRIPTION
This PR introduces support for support [`revive`](https://github.com/mgechev/revive)and [`golangci-lint`](https://github.com/golangci/golangci-lint) linters in addition to [`gometalinter`](https://github.com/alecthomas/gometalinter)

closes #819