### PR TITLE
use code blocks instead of inline code for datatips

### DIFF
--- a/lib/doc/godoc.js
+++ b/lib/doc/godoc.js
@@ -130,7 +130,9 @@ class Godoc {
 
 import "${doc.import}"
 
-\`${doc.decl}\`
+\`\`\`go
+${doc.decl}
+\`\`\`
 
 ${doc.doc}`
       }


### PR DESCRIPTION
Inline code had the side effect that any struct tags like \`json:"test"\` broke the layout of the code.
Using code blocks it now renders everything as it should including indentation and even proper highlighting if the datatip plugin understands that.