### PR TITLE
use github.com/stamblerre/gocode to get go module compatibility

### DIFF
--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -37,7 +37,7 @@ const goTools = new Map([
   ['goimports', 'golang.org/x/tools/cmd/goimports'],
   ['gorename', 'golang.org/x/tools/cmd/gorename'],
   ['goreturns', 'github.com/sqs/goreturns'],
-  ['gocode', 'github.com/mdempsky/gocode'],
+  ['gocode', 'github.com/stamblerre/gocode'],
   ['gometalinter', 'github.com/alecthomas/gometalinter'],
   ['revive', 'github.com/mgechev/revive'],
   ['golangci-lint', 'github.com/golangci/golangci-lint/cmd/golangci-lint'],


### PR DESCRIPTION
* https://github.com/mdempksy/gocode does not support `go modules`
* https://github.com/stamblerre/gocode does support `go modules` and has become the defacto `gocode` implementation

This PR switches from `mdempsky` to `stamblerre`. Note that this may introduce a small amount of additional latency when working in `GOPATH` (as opposed to a `go module`), however the go team continue to optimize the functionality of `go list`, `go/packages`, and `stamblerre/gocode`.

