### PR TITLE
Add automatic retry feature to get-manager

### DIFF
--- a/lib/get/get-manager.js
+++ b/lib/get/get-manager.js
@@ -231,8 +231,8 @@ class GetManager {
       executorOptions.timeout = timeout
     }
 
-    let retries = atom.config.get('go-plus.get.retries')
-    if (!retries || typeof retries !== 'number' || retries < 1) {
+    let retries = Number(atom.config.get('go-plus.get.retries'))
+    if (retries < 1) {
       retries = 1
     }
 
@@ -246,14 +246,15 @@ class GetManager {
     let getOutput = ''
     const promises: Array<() => Promise<GetResult>> = packages.map(
       pkg => async (): Promise<GetResult> => {
-        const args = ['get', '-u', pkg], argsStr = args.join(' ')
+        const args = ['get', '-u', pkg],
+          argsStr = args.join(' ')
         this.outputFunc().update({
           output: getOutput + '$ go ' + argsStr + os.EOL
         })
 
-        let r: ExecResult
+        let r: ExecResult = {}
         let retried = 0
-        while (true) {
+        for (;;) {
           r = await this.goconfig.executor.exec(cmd, args, executorOptions)
           if (!r.exitcode) {
             getOutput += '$ go ' + argsStr + os.EOL
@@ -261,12 +262,19 @@ class GetManager {
           }
           retried++
           if (retried < retries) {
-              this.outputFunc().update({
-                  output: getOutput
-                    + 'Retrying(' + retried + '/' + retries + '): '
-                    + '$ go ' + argsStr + os.EOL
-              })
-              continue
+            this.outputFunc().update({
+              output:
+                getOutput +
+                'Retrying(' +
+                retried +
+                '/' +
+                retries +
+                '): ' +
+                '$ go ' +
+                argsStr +
+                os.EOL
+            })
+            continue
           }
           getOutput += 'Failed: $ go ' + argsStr + os.EOL
           break

--- a/lib/get/get-manager.js
+++ b/lib/get/get-manager.js
@@ -231,6 +231,11 @@ class GetManager {
       executorOptions.timeout = timeout
     }
 
+    let retries = atom.config.get('go-plus.get.retries')
+    if (!retries || typeof retries !== 'number' || retries < 1) {
+      retries = 1
+    }
+
     // disable Go 1.11 modules, so that updating tools does not inadvertently
     // add new dependencies to the user's project
     executorOptions.env = {
@@ -241,10 +246,31 @@ class GetManager {
     let getOutput = ''
     const promises: Array<() => Promise<GetResult>> = packages.map(
       pkg => async (): Promise<GetResult> => {
-        const args = ['get', '-u', pkg]
-        getOutput += '$ go ' + args.join(' ') + os.EOL
-        this.outputFunc().update({ output: getOutput })
-        const r = await this.goconfig.executor.exec(cmd, args, executorOptions)
+        const args = ['get', '-u', pkg], argsStr = args.join(' ')
+        this.outputFunc().update({
+          output: getOutput + '$ go ' + argsStr + os.EOL
+        })
+
+        let r: ExecResult
+        let retried = 0
+        while (true) {
+          r = await this.goconfig.executor.exec(cmd, args, executorOptions)
+          if (!r.exitcode) {
+            getOutput += '$ go ' + argsStr + os.EOL
+            break
+          }
+          retried++
+          if (retried < retries) {
+              this.outputFunc().update({
+                  output: getOutput
+                    + 'Retrying(' + retried + '/' + retries + '): '
+                    + '$ go ' + argsStr + os.EOL
+              })
+              continue
+          }
+          getOutput += 'Failed: $ go ' + argsStr + os.EOL
+          break
+        }
         const result: GetResult = {
           execResult: r,
           cmd,

--- a/package.json
+++ b/package.json
@@ -371,6 +371,13 @@
           "type": "integer",
           "default": 60000,
           "order": 1
+        },
+        "retries": {
+          "title": "Retries",
+          "description": "How many times to retry when the previous update command has failed. Retry can't resolve all the problem, so choose wisely",
+          "type": "integer",
+          "default": 1,
+          "order": 2
         }
       }
     },


### PR DESCRIPTION
This pull request will add automatic retry feature to `get-manager` in order to improve the robustness of updating in an unstable network.

It will check the exitcode of `await this.goconfig.executor.exec`, namely `ExecResult.exitcode`, to determine whether or not the `go get` command is successful (see below). If not, it will go a loop and retry that command.

    if (!r.exitcode) {
        getOutput += '$ go ' + argsStr + os.EOL
        break
    }

User will be notified through the output text, for example, when retrying, the status line will be updated to:

    Retrying(3/6): $ go get -u github.com/derekparker/delve/cmd/dlv

Format: `Retrying(<How many time already tried>/<Total retry limit>)`

If later the command has failed and given up, the line will be updated to:

    Failed: $ go get -u github.com/derekparker/delve/cmd/dlv
    <Error info if available>

An Atom package option has also been added to allow user to configure the retry limit (Retry how many times). The default value of the option has been set to only 1 as retry does not resolve all the problem (It can only fix temporary problems, but temporary problems is annoying and often).

The option also been programmatically ensured cannot less than 1 using code:

    if (!retries || typeof retries !== 'number' || retries < 1) {
        retries = 1
    }