### PR TITLE
Configurable Guru Timeout

### DIFF
--- a/lib/highlight/highlight-provider.js
+++ b/lib/highlight/highlight-provider.js
@@ -42,7 +42,10 @@ class HighlightProvider {
     if (!args) return null
 
     const options = {}
-    options.timeout = 30000
+    const t = atom.config.get('go-plus.guru.timeout')
+    const timeout = typeof t === 'number' ? t : 30000
+    options.timeout = timeout
+
     const archive = buildGuruArchive(editor)
     if (archive && archive.length) {
       options.input = archive

--- a/lib/implements/implements.js
+++ b/lib/implements/implements.js
@@ -56,7 +56,10 @@ class Implements implements PanelModel {
 
   async runGuru(args: Array<string>) {
     const options = {}
-    options.timeout = 20000
+    const t = atom.config.get('go-plus.guru.timeout')
+    const timeout = typeof t === 'number' ? t : 30000
+    options.timeout = timeout
+
     const archive = buildGuruArchive()
     if (archive && archive.length) {
       options.input = archive

--- a/lib/references/references-provider.js
+++ b/lib/references/references-provider.js
@@ -76,8 +76,12 @@ class ReferencesProvider {
 
     const offset = utf8OffsetForBufferPosition(position, editor)
     const args = computeArgs('referrers', null, editor, offset) || []
+
     const options = {}
-    options.timeout = 30000
+    const t = atom.config.get('go-plus.guru.timeout')
+    const timeout = typeof t === 'number' ? t : 30000
+    options.timeout = timeout
+
     const archive = buildGuruArchive(editor)
     if (archive && archive.length) {
       options.input = archive

--- a/package.json
+++ b/package.json
@@ -384,6 +384,13 @@
           "type": "boolean",
           "default": true,
           "order": 1
+        },
+        "timeout": {
+          "title": "Timeout",
+          "description": "Stop Guru commands from runnning after this number of milliseconds",
+          "type": "integer",
+          "default": 30000,
+          "order": 2
         }
       }
     },

--- a/spec/implements/implements-spec.js
+++ b/spec/implements/implements-spec.js
@@ -72,4 +72,20 @@ describe('implements', () => {
     expect(args1.from[0].name).toBe('implements.Fooer')
     expect(args1.from[1].name).toBe('io.Reader')
   })
+
+  it('times out according to the configured guru timeout', async () => {
+    const testTimeout = 1
+    atom.config.set('go-plus.guru.timeout', testTimeout)
+    editor.setCursorBufferPosition([4, 9])
+    await impl.handleCommand()
+    expect(impl.view.update).toHaveBeenCalled()
+    expect(impl.view.update.calls.length).toBe(2)
+
+    const args0 = impl.view.update.calls[0].args[0]
+    const args1 = impl.view.update.calls[1].args[0]
+    expect(args0.startsWith('running guru')).toBe(true)
+    expect(typeof args1).toBe('string')
+    expect(args1.startsWith('guru failed')).toBe(true)
+    expect(args1.endsWith(testTimeout + ' ms')).toBe(true)
+  })
 })


### PR DESCRIPTION
This commit adds a user-configurable timeout value to all guru commands.

closes #951 

Two concerns I would like to address about the proposed changes:
* I am  encountering an issue with guru when running tests locally (both on my branch and on the HEAD of master): `guru: no initial packages were loaded`. I'm unsure if this is due to my local dev environment, so I wanted to see if the tests pass in the CI environment.
* It is proving to be very difficult to test the highlight provider guru timeout. this guru operation seems to work pretty quickly in the test environment. When I set a timeout of 1ms in the package settings during normal usage, the command does not seem to finish within 1ms and no identifiers in the editor are highlighted. when I set a timeout of 1ms in a spec, the highlight provider's highlight function seems to finish before the timeout, and valid highlight ranges are returned by the function. I'm not sure if it's going to be possible to test the timeout of the highlight provider.